### PR TITLE
Fix #2 green background in terminals

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -848,7 +848,9 @@ This requires library `rainbow-mode'.")
      (boundp 'custom-theme-load-path)
      (add-to-list 'custom-theme-load-path
                   (file-name-as-directory
-                   (file-name-directory load-file-name))))
+                   (file-name-directory load-file-name)))
+     (when (not window-system)
+       (custom-set-faces '(default ((t (:background "nil")))))))
 
 (provide-theme 'monokai)
 


### PR DESCRIPTION
Credit for the fix should go to lvillani's el-monokai-theme.
