### PR TITLE
replace hl color with a more distinguishable color

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -141,7 +141,7 @@ Takes and optional `FRAME' as reference."
          (monokai-fg       (if (in-terminal) "#F5F5F5" "#F8F8F2"))
          (monokai-bg       (if (in-terminal) "#1B1E1C" "#272822"))
          (monokai-hl-line  (if (in-terminal) "#212121" "#3E3D31"))
-         (monokai-hl       (if (in-terminal) "#303030" "#49483E"))
+         (monokai-hl       (if (in-terminal) "#303030" "#9D550F"))
          (monokai-emph     (if (in-terminal) "#FFFAFA" "#F8F8F0"))
          (monokai-comments (if (in-terminal) "#8B8878" "#75715E"))
 


### PR DESCRIPTION
Because it's hard to distinguish hl color and hl-line color, especially
when just marking part of one line.
So I replace hl color with selection color of Sublime Text's Monokai
Bright Theme.

Change-Id: I30ac9505c78db871a7cfe4dcbac8a9eb01f43c56
