### PR TITLE
Change logic on Emacs version check.

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -44,7 +44,7 @@
 ;;
 ;;; Code:
 
-(unless (>= 24 emacs-major-version)
+(unless (>= emacs-major-version 24)
   (error "The monokai theme requires Emacs 24 or later!"))
 
 (deftheme monokai "The Monokai colour theme")


### PR DESCRIPTION
The original version works for Emacs 24, but nothing beyond that. I ran into this because the latest Emacs head is reporting its version as `25.0.50.1`.
