### PR TITLE
Add face for perspective.el

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -4007,6 +4007,11 @@ Also affects 'linum-mode' background."
    `(paren-face
      ((,terminal-class (:foreground ,monokai-comments))))
 
+   ;; perspective
+   `(persp-selected-face
+     ((,class (:foreground ,blue
+                           :weight bold))))
+
    ;; pretty-mode
    `(pretty-mode-symbol-face
      ((,class (:foreground ,yellow


### PR DESCRIPTION
I just started using [perspective.el](https://github.com/nex3/perspective-el) and it's pretty great, but the default face is the standard "Blue" and looks nearly unreadable and pretty ugly. 

Here's a preview of what this change looks like:

![Perspective face preview](http://i.imgur.com/m3JqHu2.png)

I've also just noticed that this pull request includes a change I've made to ensure monokai-theme.el disables aggressive-indent-mode. I found that Emacs locks up and becomes unresponsive when editing this file with aggressive-indent on — guessing that the file is too big, or at least the `custom-theme-set-faces` declaration is too big.
