### PR TITLE
Theming support for company annotations and template fields

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1344,7 +1344,21 @@ Also affects 'linum-mode' background."
      ((,class (:background ,yellow-d))
       (,terminal-class (:background ,terminal-yellow-d))))
 
-   ;; cscope
+   ;; company-mode tooltip annnotations
+   `(company-tooltip-annotation
+     ((,class (:background ,monokai-hl
+                           :foreground ,green-l))
+      (,terminal-class (:background ,terminal-monokai-hl
+                                    :foreground ,terminal-green))))
+
+   ;; company-mode templates
+   `(company-template-field
+     ((,class (:background ,monokai-hl
+                           :foreground ,cyan))
+      (,terminal-class (:background ,terminal-monokai-hl
+                                    :foreground ,terminal-cyan))))
+
+   ;; CSCOPE
    `(cscope-file-face
      ((,class (:foreground ,green
                            :weight bold))


### PR DESCRIPTION
If a backend provides support for company annotations (see screenshots), then these are colored in bright green, instead of the default red.

![image](https://cloud.githubusercontent.com/assets/174208/6263466/fc211388-b820-11e4-873b-33408ff9cd1d.png)

If a backend provides support for template fields, these are colored exactly like the tooltip suggestions, instead of the default yellow.

![image](https://cloud.githubusercontent.com/assets/174208/6263471/136abaee-b821-11e4-9775-a2f597e33158.png)

*After navigating to Fscanf and hitting enter.*