### PR TITLE
Maintain powerline support for f2c7be4

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -175,7 +175,7 @@ Also affects 'linum-mode' background."
 
        ;; powerline
        (s-powerline-active1-bg   (if monokai-high-contrast-mode-line
-                                     monokai-gray-l monokai-gray))
+                                     monokai-gray-l monokai-highlight-line))
        (s-powerline-active2-bg   (if monokai-high-contrast-mode-line
                                      monokai-gray monokai-gray-l))
        (s-powerline-inactive1-bg (if monokai-high-contrast-mode-line


### PR DESCRIPTION
This pull req fixes ``s-powerline-active1-bg`` color because it's the same color as ``s-mode-line-bg``.