### PR TITLE
Also fix color clash in company complete pop-up for terminal

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1239,6 +1239,7 @@ Also affects 'linum-mode' background."
                            :background ,monokai-blue
                            :underline t))
       (,terminal-class (:foreground ,terminal-monokai-bg
+                                    :background ,terminal-monokai-blue
                                     :underline t))))
 
    `(company-preview


### PR DESCRIPTION
Hi there,

I'm not totally sure this pull request is the right way to fix the display problem I have.
It has already been reported in #40 and has been fixed by #41.
However, the main difference it that the previous reporter seems to use emacs in a graphical environment and that I use it in a terminal.
It looks like I simply have to add the corresponding terminal declaration for it to be properly displayed.

Without the patch:
<img width="60" alt="screen shot 2016-05-15 at 13 01 22" src="https://cloud.githubusercontent.com/assets/3048933/15273551/79e5cb44-1a9d-11e6-8231-863ef25a2eb0.png">

With the patch:
<img width="60" alt="screen shot 2016-05-15 at 13 02 14" src="https://cloud.githubusercontent.com/assets/3048933/15273553/8231fec6-1a9d-11e6-961b-15ccbbf3e671.png">

Regards.
