### PR TITLE
add faces for which-key

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -5652,6 +5652,34 @@ Also affects 'linum-mode' background."
      ((,class (:foreground ,monokai-green))
       (,terminal-class (:foreground ,terminal-monokai-green))))
 
+   ;; which-key
+   `(which-key-key-face
+     ((,class (:foreground ,monokai-green
+			   :weight bold))
+      (,terminal-class (:foreground ,terminal-monokai-green
+				    :weight bold))))
+
+   `(which-key-separator-face
+     ((,class (:foreground ,monokai-comments))
+      (,terminal-class (:foreground ,terminal-monokai-comments))))
+
+   `(which-key-note-face
+     ((,class (:foreground ,monokai-comments))
+      (,terminal-class (:foreground ,terminal-monokai-comments))))
+
+   `(which-key-command-description-face
+     ((,class (:foreground ,monokai-fg))
+      (,terminal-class (:foreground ,terminal-monokai-fg))))
+
+   `(which-key-local-map-description-face
+     ((,class (:foreground ,monokai-yellow-hc))
+      (,terminal-class (:foreground ,terminal-monokai-yellow-hc))))
+
+   `(which-key-group-description-face
+     ((,class (:foreground ,monokai-red
+			   :weight bold))
+      (,terminal-class (:foreground ,terminal-monokai-red
+				    :weight bold))))
    ;; window-number-mode
    `(window-number-face
      ((,class (:foreground ,monokai-green))


### PR DESCRIPTION
Add support for [which-key](https://github.com/justbur/emacs-which-key) faces.

Before:
![screenshot from 2016-06-27 20-13-06](https://cloud.githubusercontent.com/assets/6248219/16390604/e1b761ce-3ca3-11e6-9a4d-880b2437ddbe.png)

Now:

![screenshot from 2016-06-27 20-09-57](https://cloud.githubusercontent.com/assets/6248219/16390615/eb72dca2-3ca3-11e6-84b7-3d45eca84399.png)

Note that local-map specific commands are slightly yellow, making them distinguishable but not as bright as command groups so that it remains instinctive that it is a command and not a command group.

**NB:** Some of the faces I wasn't exactly sure what they did so I left them commented for information to the reader.