### PR TITLE
Expose foreground, background and primary colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ To load it automatically on Emacs startup add this to your init file:
 (load-theme 'monokai t)
 ```
 
+## Customization
+
+Please see full list of variables in the `defcustom` section.
+
+i.e.:
+```lisp
+  (setq monokai-fg "#ABB2BF"
+        monokai-bg "#282C34"
+        monokai-blue "#61AFEF"
+        monokai-cyan "#56B6C2"
+        monokai-green "#98C379"
+        monokai-gray "#3E4451"
+        monokai-violet "#C678DD"
+        monokai-red "#E06C75"
+        monokai-orange "#D19A66"
+        monokai-yellow "#E5C07B")
+```
+
 # Bugs & Improvements
 
 Please, report any problems that you find on the projects integrated

--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -93,6 +93,62 @@ Also affects 'linum-mode' background."
   :type 'number
   :group 'monokai)
 
+;; Primary colors
+(defcustom monokai-yellow "#E6DB74"
+  "Primary colors - yellow"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-orange "#FD971F"
+  "Primary colors - orange"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-red "#F92672"
+  "Primary colors - red"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-magenta "#FD5FF0"
+  "Primary colors - magenta"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-blue "#66D9EF"
+  "Primary colors - blue"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-green "#A6E22E"
+  "Primary colors - green"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-cyan "#A1EFE4"
+  "Primary colors - cyan"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-violet "#AE81FF"
+  "Primary colors - violet"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-gray "#3E3D31"
+  "Primary colors - gray"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-fg "#F8F8F2"
+  "Adaptive colors - foreground"
+  :type 'string
+  :group 'monokai)
+
+(defcustom monokai-bg "#272822"
+  "Adaptive colors - background"
+  :type 'string
+  :group 'monokai)
+
 (let* (;; Variable pitch
        (monokai-pitch (if monokai-use-variable-pitch
                           'variable-pitch
@@ -100,16 +156,6 @@ Also affects 'linum-mode' background."
 
        ;; Definitions for guis that support 256 colors
        (class                    '((class color) (min-colors 257)))
-       ;; Primary colors
-       (monokai-yellow           "#E6DB74")
-       (monokai-orange           "#FD971F")
-       (monokai-red              "#F92672")
-       (monokai-magenta          "#FD5FF0")
-       (monokai-violet           "#AE81FF")
-       (monokai-blue             "#66D9EF")
-       (monokai-cyan             "#A1EFE4")
-       (monokai-green            "#A6E22E")
-       (monokai-gray             "#3E3D31")
        ;; Darker and lighter accented colors
        (monokai-yellow-d         "#BEB244")
        (monokai-yellow-l         "#FFF7A8")
@@ -130,8 +176,6 @@ Also affects 'linum-mode' background."
        (monokai-gray-d           "#35331D")
        (monokai-gray-l           "#7B7962")
        ;; Adaptive colors
-       (monokai-fg               "#F8F8F2")
-       (monokai-bg               "#272822")
        (monokai-highlight-line   "#49483E")
        (monokai-highlight        "#FFB269")
        (monokai-emph             "#F8F8F0")


### PR DESCRIPTION
Fixes https://github.com/oneKelvinSmith/monokai-emacs/issues/59

How to use it:
```lisp
  (setq monokai-fg "#ABB2BF"
        monokai-bg "#282C34"
        monokai-blue "#61AFEF"
        monokai-cyan "#56B6C2"
        monokai-green "#98C379"
        monokai-gray "#3E4451"
        monokai-violet "#C678DD"
        monokai-red "#E06C75"
        monokai-orange "#D19A66"
        monokai-yellow "#E5C07B")
```

Before:
![image](https://cloud.githubusercontent.com/assets/12563308/17317848/9553a24e-5836-11e6-8165-8ca75f03d2df.png)

After:
![image](https://cloud.githubusercontent.com/assets/12563308/17317859/a3f26222-5836-11e6-9a84-71c3128d59ed.png)
