### PR TITLE
Use monokai-highlight for helm-selection

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -2745,10 +2745,10 @@ Also affects 'linum-mode' background."
       (,terminal-class (:inherit helm-match))))
 
    `(helm-selection
-     ((,class (:background ,monokai-highlight-line
+     ((,class (:background ,monokai-highlight
                            :inherit bold
                            :underline nil))
-      (,terminal-class (:background ,terminal-monokai-highlight-line
+      (,terminal-class (:background ,terminal-monokai-highlight
                                     :inherit bold
                                     :underline nil))))
 


### PR DESCRIPTION
monokai-highlight-line doesn't have enough contrast by default for something as important as current selection.