### PR TITLE
resolves #68 Markup Faces / adoc-mode - Some text barely readable

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -4031,6 +4031,10 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-comments))
       (,monokai-256-class  (:foreground ,monokai-256-comments))))
 
+   ;; adoc-mode / markup
+   `(markup-meta-face
+     ((,monokai-class (:foreground ,monokai-gray-l))
+      (,monokai-256-class  (:foreground ,monokai-256-gray-l))))
 
    ;; org-mode
    `(org-agenda-structure


### PR DESCRIPTION
I don't like the concept of markup-meta-hide-face but I guess a theme shouldn't break this concept, so I didn't touch it.
I'm happy about suggestions regarding the color.

Preview:
![emacs_adoc_monokai-gray-l](https://cloud.githubusercontent.com/assets/459631/21221301/2775f82a-c2bd-11e6-9c0c-095f97e5622a.png)

Without this PR:
![emacs_monokai_adoc](https://cloud.githubusercontent.com/assets/459631/21217535/eec1a214-c2ac-11e6-96b8-49ac131915ce.png)

Edit: here is the file used for my example screenshots https://raw.githubusercontent.com/vogellacompany/com.vogella.tutorials.technology/master/AsciiDoc/010_overview.adoc