### PR TITLE
Adds full monokai support for adoc-mode

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -4036,6 +4036,40 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-gray-l))
       (,monokai-256-class  (:foreground ,monokai-256-gray-l))))
 
+   `(markup-table-face
+     ((,monokai-class (:foreground ,monokai-blue-hc
+                                   :background ,monokai-blue-lc))
+      (,monokai-256-class  (:foreground ,monokai-256-blue-hc
+                                        :background ,monokai-256-blue-lc))))
+
+   `(markup-verbatim-face
+     ((,monokai-class (:background ,monokai-orange-lc))
+      (,monokai-256-class  (:background ,monokai-256-orange-lc))))
+
+   `(markup-list-face
+     ((,monokai-class (:foreground ,monokai-violet-hc
+                                   :background ,monokai-violet-lc))
+      (,monokai-256-class  (:foreground ,monokai-256-violet-hc
+                                        :background ,monokai-256-violet-lc))))
+
+   `(markup-replacement-face
+     ((,monokai-class (:foreground ,monokai-violet))
+      (,monokai-256-class  (:foreground ,monokai-256-violet))))
+
+   `(markup-complex-replacement-face
+     ((,monokai-class (:foreground ,monokai-violet-hc
+                                   :background ,monokai-violet-lc))
+      (,monokai-256-class  (:foreground ,monokai-256-violet-hc
+                                        :background ,monokai-256-violet-lc))))
+
+   `(markup-gen-face
+     ((,monokai-class (:foreground ,monokai-blue))
+      (,monokai-256-class  (:foreground ,monokai-256-blue))))
+
+   `(markup-secondary-text-face
+     ((,monokai-class (:foreground ,monokai-red))
+      (,monokai-256-class  (:foreground ,monokai-256-red))))
+
    ;; org-mode
    `(org-agenda-structure
      ((,monokai-class (:foreground ,monokai-emphasis


### PR DESCRIPTION
Tried a full conversion to monokai, let me know if you like it.
Table color scheme is a bit hard to read when it's only one character? =\

![emacs_monokai_added_colors](https://cloud.githubusercontent.com/assets/459631/21223262/9faf4c5c-c2c6-11e6-8490-cd63c75bc572.png)
![emacs_monokai_added_colors2](https://cloud.githubusercontent.com/assets/459631/21223261/9f916e26-c2c6-11e6-8735-dbe5556078de.png)
![emacs_monokai_added_colors3](https://cloud.githubusercontent.com/assets/459631/21223585/3438a4d0-c2c8-11e6-9742-d803f2d6d1ea.png)
