### PR TITLE
FIX: show-paren-mode erroneously highlights the left margin.

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -3218,9 +3218,11 @@ Also affects 'linum-mode' background."
    `(linum
      ((,monokai-class (:foreground ,monokai-line-number
                                    :background ,monokai-fringe-bg
+                                   :inherit default
                                    :underline nil))
       (,monokai-256-class  (:foreground ,monokai-256-line-number
                                         :background ,monokai-256-fringe-bg
+                                        :inherit default
                                         :underline nil))))
 
    ;; linum-relative-current-face


### PR DESCRIPTION
Please refer to https://lists.gnu.org/archive/html/bug-gnu-emacs/2015-10/msg01050.html