### PR TITLE
Makes isearch simmilar to sublime

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -799,9 +799,11 @@ Also affects 'linum-mode' background."
    ;; isearch
    `(isearch
      ((,monokai-class (:inherit region
-                                :background ,monokai-green))
+                                :foreground ,monokai-background
+                                :background ,monokai-yellow))
       (,monokai-256-class  (:inherit region
-                                     :background ,monokai-256-green))))
+                                     :foreground ,monokai-256-background
+                                     :background ,monokai-256-yellow))))
 
    `(isearch-fail
      ((,monokai-class (:inherit isearch


### PR DESCRIPTION
In sublime, when searching, the highlight is in yellow and the text is collored the same as the background, so I tought I should make it identical here as well. The green color that was used previously, without changing the foreground collor looked really bad especially when matching text that was already collored green.