### PR TITLE
Better handling of vhl colors

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -5260,10 +5260,8 @@ Also affects 'linum-mode' background."
 
    ;; volatile highlights
    `(vhl/default-face
-     ((,monokai-class (:background ,monokai-green-lc
-                                   :foreground ,monokai-green-hc))
-      (,monokai-256-class  (:background ,monokai-256-green-lc
-                                        :foreground ,monokai-256-green-hc))))
+      ((,monokai-class (:background ,monokai-highlight-alt))
+        (,monokai-256-class  (:background ,monokai-256-highlight-alt))))
 
    ;; w3m
    `(w3m-anchor


### PR DESCRIPTION
Pasting a lot of text, or navigating the kill ring was a pain since the text was all green, together with a greener background, without syntax highliting and made it look pooly. I changed it to a dark gray background, similar to a visual select.