### PR TITLE
Adds theme colors for treemacs

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -5215,6 +5215,61 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :inherit ,monokai-pitch))))
 
+   ;; treemacs
+   `(treemacs-directory-face
+      ((,monokai-class (:foreground ,monokai-violet
+                         :background ,monokai-background
+                         :weight bold))
+        (,monokai-256-class (:foreground ,monokai-256-violet
+                              :background ,monokai-256-background
+                              :weight bold))))
+
+   `(treemacs-header-face
+      ((,monokai-class (:foreground ,monokai-yellow
+                         :background ,monokai-background
+                         :underline t
+                         :weight bold))
+        (,monokai-256-class (:foreground ,monokai-256-yellow
+                              :background ,monokai-256-background
+                              :underline t
+                              :weight bold))))
+
+   `(treemacs-git-modified-face
+      ((,monokai-class (:foreground ,monokai-green
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-green
+                              :background ,monokai-256-background))))
+
+   `(treemacs-git-renamed-face
+      ((,monokai-class (:foreground ,monokai-red
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-red
+                              :background ,monokai-256-background))))
+
+   `(treemacs-git-ignored-face
+      ((,monokai-class (:foreground ,monokai-gray-l
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-gray-l
+                              :background ,monokai-256-background))))
+
+   `(treemacs-git-untracked-face
+      ((,monokai-class (:foreground ,monokai-red
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-red
+                              :background ,monokai-256-background))))
+
+   `(treemacs-git-added-face
+      ((,monokai-class (:foreground ,monokai-green
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-green
+                              :background ,monokai-256-background))))
+
+   `(treemacs-git-conflict-face
+      ((,monokai-class (:foreground ,monokai-orange
+                         :background ,monokai-background))
+        (,monokai-256-class (:foreground ,monokai-256-orange
+                              :background ,monokai-256-background))))
+
    ;; tuareg
    `(tuareg-font-lock-governing-face
      ((,monokai-class (:foreground ,monokai-magenta


### PR DESCRIPTION
Makes treemacs look like I remember nerdtree used to look in vim with the monokai color scheme. Also made git statuses look like `git status` shows them in the terminal.

/cc @Alexander-Miller 

![screenshot_2018-02-09_00-54-03](https://user-images.githubusercontent.com/3746963/36002805-29cfd8da-0d34-11e8-8efc-686478f4a257.png)
