### PR TITLE
Fix font-latex-doctex-preprocessor-face for 256 color terminals

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -881,7 +881,7 @@ Also affects 'linum-mode' background."
        (:inherit (font-latex-doctex-documentation-face
                   font-lock-builtin-face
                   font-lock-preprocessor-face)))
-      (,monokai-class
+      (,monokai-256-class
        (:inherit (font-latex-doctex-documentation-face
                   font-lock-builtin-face
                   font-lock-preprocessor-face)))))


### PR DESCRIPTION
Fix font-latex-doctex-preprocessor-face when using a terminal with 256 colors.