### PR TITLE
Add face for centaur-tabs

### DIFF
--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1118,11 +1118,11 @@ Also affects 'linum-mode' background."
                                        :foreground ,monokai-256-background))))
 
    ;; centaur-tabs
-   `(centaur-tabs-default ((t (:background ,monokai-background :foreground ,monokai-gray-d :box nil))))
-   `(centaur-tabs-selected ((t (:background ,monokai-emphasis :foreground ,monokai-comments :box nil))))
-   `(centaur-tabs-unselected ((t (:background ,monokai-background :foreground ,monokai-comments :box nil))))
-   `(centaur-tabs-selected-modified ((t (:background ,monokai-emphasis :foreground ,monokai-orange :box nil))))
-   `(centaur-tabs-unselected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
+   `(centaur-tabs-default ((t (:background ,monokai-highlight-line :foreground ,monokai-gray-d :box nil))))
+   `(centaur-tabs-selected ((t (:background ,monokai-background :foreground ,monokai-comments :box nil))))
+   `(centaur-tabs-unselected ((t (:background ,monokai-highlight-line :foreground ,monokai-comments :box nil))))
+   `(centaur-tabs-selected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
+   `(centaur-tabs-unselected-modified ((t (:background ,monokai-highlight-line :foreground ,monokai-orange :box nil))))
    `(centaur-tabs-active-bar-face ((t (:background ,monokai-yellow :box nil))))
    `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-yellow :box nil))))
    `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-yellow :box nil))))

--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1124,8 +1124,8 @@ Also affects 'linum-mode' background."
    `(centaur-tabs-selected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
    `(centaur-tabs-unselected-modified ((t (:background ,monokai-highlight-line :foreground ,monokai-orange :box nil))))
    `(centaur-tabs-active-bar-face ((t (:background ,monokai-background :box nil))))
-   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-background :box nil))))
-   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-background :box nil))))
+   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-gray-l :box nil))))
+   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-gray-l :box nil))))
    
    ;; calfw
    `(cfw:face-day-title

--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1123,9 +1123,9 @@ Also affects 'linum-mode' background."
    `(centaur-tabs-unselected ((t (:background ,monokai-highlight-line :foreground ,monokai-comments :box nil))))
    `(centaur-tabs-selected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
    `(centaur-tabs-unselected-modified ((t (:background ,monokai-highlight-line :foreground ,monokai-orange :box nil))))
-   `(centaur-tabs-active-bar-face ((t (:background ,monokai-red :box nil))))
-   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-red :box nil))))
-   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-red :box nil))))
+   `(centaur-tabs-active-bar-face ((t (:background ,monokai-background :box nil))))
+   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-background :box nil))))
+   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-background :box nil))))
    
    ;; calfw
    `(cfw:face-day-title

--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -333,7 +333,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(font-lock-comment-delimiter-face
      ((,monokai-class (:foreground ,monokai-comments))
@@ -363,13 +363,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(font-lock-negation-char-face
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(font-lock-preprocessor-face
      ((,monokai-class (:foreground ,monokai-red))
@@ -379,13 +379,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(font-lock-regexp-grouping-backslash
      ((,monokai-class (:foreground ,monokai-violet
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(font-lock-string-face
      ((,monokai-class (:foreground ,monokai-yellow))
@@ -395,7 +395,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :italic nil))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :italic nil))))
+                                       :italic nil))))
 
    `(font-lock-variable-name-face
      ((,monokai-class (:foreground ,monokai-orange))
@@ -407,9 +407,9 @@ Also affects 'linum-mode' background."
                                    :italic t
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight bold
-                                        :italic t
-                                        :underline t))))
+                                       :weight bold
+                                       :italic t
+                                       :underline t))))
 
    `(c-annotation-face
      ((,monokai-class (:inherit font-lock-constant-face))
@@ -422,7 +422,7 @@ Also affects 'linum-mode' background."
       ((,monokai-class (:foreground ,monokai-foreground
                                     :background ,monokai-background))
        (,monokai-256-class (:foreground ,monokai-256-foreground
-                                         :background ,monokai-256-background))))
+                                        :background ,monokai-256-background))))
 
    `(highlight
      ((,monokai-class (:background ,monokai-highlight))
@@ -432,19 +432,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit highlight
                                 :background ,monokai-highlight-alt))
       (,monokai-256-class (:inherit highlight
-                                     :background ,monokai-256-highlight-alt))))
+                                    :background ,monokai-256-highlight-alt))))
 
    `(region
      ((,monokai-class (:inherit highlight
                                 :background ,monokai-highlight))
       (,monokai-256-class (:inherit highlight
-                                     :background ,monokai-256-highlight))))
+                                    :background ,monokai-256-highlight))))
 
    `(secondary-selection
      ((,monokai-class (:inherit region
                                 :background ,monokai-highlight-alt))
       (,monokai-256-class (:inherit region
-                                     :background ,monokai-256-highlight-alt))))
+                                    :background ,monokai-256-highlight-alt))))
 
    `(shadow
      ((,monokai-class (:foreground ,monokai-comments))
@@ -455,24 +455,24 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background
-                                        :weight bold))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold))))
 
    `(cursor
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-foreground
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-foreground
-                                        :inverse-video t))))
+                                       :background ,monokai-256-foreground
+                                       :inverse-video t))))
 
    `(mouse
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-foreground
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-foreground
-                                        :inverse-video t))))
+                                       :background ,monokai-256-foreground
+                                       :inverse-video t))))
 
    `(escape-glyph
      ((,monokai-class (:foreground ,monokai-comments))
@@ -486,23 +486,23 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :background ,monokai-fringe-bg))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :background ,monokai-256-fringe-bg))))
+                                       :background ,monokai-256-fringe-bg))))
 
    `(link
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline t
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline t
-                                        :weight bold))))
+                                       :underline t
+                                       :weight bold))))
 
    `(link-visited
      ((,monokai-class (:foreground ,monokai-violet
                                    :underline t
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :underline t
-                                        :weight normal))))
+                                       :underline t
+                                       :weight normal))))
 
    `(success
      ((,monokai-class (:foreground ,monokai-green ))
@@ -520,13 +520,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-green))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-green))))
+                                       :background ,monokai-256-green))))
 
    `(eval-sexp-fu-flash-error
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-red))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-red))))
+                                       :background ,monokai-256-red))))
 
    `(trailing-whitespace
      ((,monokai-class (:background ,monokai-red))
@@ -540,7 +540,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(minibuffer-prompt
      ((,monokai-class (:foreground ,monokai-blue))
@@ -551,7 +551,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(mode-line
      ((,monokai-class (:inverse-video unspecified
@@ -562,12 +562,12 @@ Also affects 'linum-mode' background."
                                                         :color ,monokai-gray
                                                         :style unspecified)))
       (,monokai-256-class (:inverse-video unspecified
-                                           :underline unspecified
-                                           :foreground ,monokai-256-foreground
-                                           :background ,monokai-256-background
-                                           :box (:line-width 1
-                                                             :color ,monokai-256-highlight
-                                                             :style unspecified)))))
+                                          :underline unspecified
+                                          :foreground ,monokai-256-foreground
+                                          :background ,monokai-256-background
+                                          :box (:line-width 1
+                                                            :color ,monokai-256-highlight
+                                                            :style unspecified)))))
 
    `(powerline-active1
      ((,monokai-class (:background ,monokai-gray-d))
@@ -587,12 +587,12 @@ Also affects 'linum-mode' background."
                                                         :color ,monokai-gray
                                                         :style unspecified)))
       (,monokai-256-class (:inverse-video unspecified
-                                           :underline unspecified
-                                           :foreground ,monokai-256-comments
-                                           :background ,monokai-256-background
-                                           :box (:line-width 1
-                                                             :color ,monokai-256-gray
-                                                             :style unspecified)))))
+                                          :underline unspecified
+                                          :foreground ,monokai-256-comments
+                                          :background ,monokai-256-background
+                                          :box (:line-width 1
+                                                            :color ,monokai-256-gray
+                                                            :style unspecified)))))
 
    `(powerline-inactive1
      ((,monokai-class (:background ,monokai-gray-d))
@@ -610,17 +610,17 @@ Also affects 'linum-mode' background."
                                                 :line-width 1
                                                 :style unspecified)))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-highlight
-                                        :box (:color ,monokai-256-gray
-                                                     :line-width 1
-                                                     :style unspecified)))))
+                                       :background ,monokai-256-highlight
+                                       :box (:color ,monokai-256-gray
+                                                    :line-width 1
+                                                    :style unspecified)))))
 
    ;; cua
    `(cua-global-mark
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(cua-rectangle
      ((,monokai-class (:inherit region))
@@ -649,8 +649,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background
-                                        :inherit bold))))
+                                       :background ,monokai-256-background
+                                       :inherit bold))))
 
    `(dired-ignored
      ((,monokai-class (:inherit shadow))
@@ -660,83 +660,83 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(dired-marked
      ((,monokai-class (:foreground ,monokai-violet
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(dired-perm-write
      ((,monokai-class (:foreground ,monokai-foreground
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :underline t))))
+                                       :underline t))))
 
    `(dired-symlink
      ((,monokai-class (:foreground ,monokai-cyan
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :slant italic))))
+                                       :slant italic))))
 
    `(dired-warning
      ((,monokai-class (:foreground ,monokai-orange
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :underline t))))
+                                       :underline t))))
 
    ;; dropdown
    `(dropdown-list-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-blue))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-blue))))
+                                       :foreground ,monokai-256-blue))))
 
    `(dropdown-list-selection-face
      ((,monokai-class (:background ,monokai-green
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    ;; ecb
    `(ecb-default-highlight-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(ecb-history-bucket-node-dir-soure-path-face
      ((,monokai-class (:inherit ecb-history-bucket-node-face
                                 :foreground ,monokai-yellow))
       (,monokai-256-class (:inherit ecb-history-bucket-node-face
-                                     :foreground ,monokai-256-yellow))))
+                                    :foreground ,monokai-256-yellow))))
 
    `(ecb-source-in-directories-buffer-face
      ((,monokai-class (:inherit ecb-directories-general-face
                                 :foreground ,monokai-foreground))
       (,monokai-256-class (:inherit ecb-directories-general-face
-                                     :foreground ,monokai-256-foreground))))
+                                    :foreground ,monokai-256-foreground))))
 
    `(ecb-history-dead-buffer-face
      ((,monokai-class (:inherit ecb-history-general-face
                                 :foreground ,monokai-comments))
       (,monokai-256-class (:inherit ecb-history-general-face
-                                     :foreground ,monokai-256-comments))))
+                                    :foreground ,monokai-256-comments))))
 
    `(ecb-directory-not-accessible-face
      ((,monokai-class (:inherit ecb-directories-general-face
                                 :foreground ,monokai-comments))
       (,monokai-256-class (:inherit ecb-directories-general-face
-                                     :foreground ,monokai-256-comments))))
+                                    :foreground ,monokai-256-comments))))
 
    `(ecb-bucket-node-face
      ((,monokai-class (:inherit ecb-default-general-face
                                 :weight normal
                                 :foreground ,monokai-blue))
       (,monokai-256-class (:inherit ecb-default-general-face
-                                     :weight normal
-                                     :foreground ,monokai-256-blue))))
+                                    :weight normal
+                                    :foreground ,monokai-256-blue))))
 
    `(ecb-tag-header-face
      ((,monokai-class (:background ,monokai-highlight-line))
@@ -746,19 +746,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit ecb-analyse-general-face
                                 :foreground ,monokai-green))
       (,monokai-256-class (:inherit ecb-analyse-general-face
-                                     :foreground ,monokai-256-green))))
+                                    :foreground ,monokai-256-green))))
 
    `(ecb-directories-general-face
      ((,monokai-class (:inherit ecb-default-general-face
                                 :height 1.0))
       (,monokai-256-class (:inherit ecb-default-general-face
-                                     :height 1.0))))
+                                    :height 1.0))))
 
    `(ecb-method-non-semantic-face
      ((,monokai-class (:inherit ecb-methods-general-face
                                 :foreground ,monokai-cyan))
       (,monokai-256-class (:inherit ecb-methods-general-face
-                                     :foreground ,monokai-256-cyan))))
+                                    :foreground ,monokai-256-cyan))))
 
    `(ecb-mode-line-prefix-face
      ((,monokai-class (:foreground ,monokai-green))
@@ -769,8 +769,8 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-gray
                                 :height 1.0))
       (,monokai-256-class (:inherit ecb-default-general-face
-                                     :foreground ,monokai-256-gray
-                                     :height 1.0))))
+                                    :foreground ,monokai-256-gray
+                                    :height 1.0))))
 
    ;; ee
    `(ee-bookmarked
@@ -793,7 +793,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-magenta
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(ee-omitted
      ((,monokai-class (:foreground ,monokai-comments))
@@ -813,8 +813,8 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
    `(grep-hit-face
      ((,monokai-class (:foreground ,monokai-orange))
@@ -824,7 +824,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; isearch
    `(isearch
@@ -832,8 +832,8 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-background
                                 :background ,monokai-yellow))
       (,monokai-256-class (:inherit region
-                                     :foreground ,monokai-256-background
-                                     :background ,monokai-256-yellow))))
+                                    :foreground ,monokai-256-background
+                                    :background ,monokai-256-yellow))))
 
    `(isearch-fail
      ((,monokai-class (:inherit isearch
@@ -841,9 +841,9 @@ Also affects 'linum-mode' background."
                                 :background ,monokai-background
                                 :bold t))
       (,monokai-256-class (:inherit isearch
-                                     :foreground ,monokai-256-red
-                                     :background ,monokai-256-background
-                                     :bold t))))
+                                    :foreground ,monokai-256-red
+                                    :background ,monokai-256-background
+                                    :bold t))))
 
 
    ;; ace-jump-mode
@@ -852,8 +852,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :inverse-video nil))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-background
-                                        :inverse-video nil))))
+                                       :background ,monokai-256-background
+                                       :inverse-video nil))))
 
    `(ace-jump-face-foreground
      ((,monokai-class (:foreground ,monokai-yellow
@@ -861,16 +861,16 @@ Also affects 'linum-mode' background."
                                    :inverse-video nil
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background ,monokai-256-background
-                                        :inverse-video nil
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :inverse-video nil
+                                       :weight bold))))
 
    ;; auctex
    `(font-latex-bold-face
      ((,monokai-class (:inherit bold
                                 :foreground ,monokai-emphasis))
       (,monokai-256-class (:inherit bold
-                                     :foreground ,monokai-256-emphasis))))
+                                    :foreground ,monokai-256-emphasis))))
 
    `(font-latex-doctex-documentation-face
      ((,monokai-class (:background unspecified))
@@ -898,39 +898,39 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit font-latex-sectioning-1-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit font-latex-sectioning-1-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(font-latex-sectioning-1-face
      ((,monokai-class (:inherit font-latex-sectioning-2-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit font-latex-sectioning-2-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(font-latex-sectioning-2-face
      ((,monokai-class (:inherit font-latex-sectioning-3-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit font-latex-sectioning-3-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(font-latex-sectioning-3-face
      ((,monokai-class (:inherit font-latex-sectioning-4-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit font-latex-sectioning-4-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(font-latex-sectioning-4-face
      ((,monokai-class (:inherit font-latex-sectioning-5-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit font-latex-sectioning-5-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(font-latex-sectioning-5-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-yellow
                                 :weight bold))
       (,monokai-256-class (:inherit ,monokai-pitch :
-                                     foreground ,monokai-256-yellow
-                                     :weight bold))))
+                                    foreground ,monokai-256-yellow
+                                    :weight bold))))
 
    `(font-latex-sedate-face
      ((,monokai-class (:foreground ,monokai-emphasis))
@@ -941,8 +941,8 @@ Also affects 'linum-mode' background."
                                 :weight bold
                                 :height ,monokai-height-plus-3))
       (,monokai-256-class (:inherit (,monokai-pitch font-lock-type-face)
-                                     :weight bold
-                                     :height ,monokai-height-plus-3))))
+                                    :weight bold
+                                    :height ,monokai-height-plus-3))))
 
    `(font-latex-string-face
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -961,106 +961,106 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-foreground
                                 :slant italic))
       (,monokai-256-class (:inherit fixed-pitch
-                                     :foreground ,monokai-256-foreground
-                                     :slant italic))))
+                                    :foreground ,monokai-256-foreground
+                                    :slant italic))))
 
    `(font-latex-warning-face
      ((,monokai-class (:inherit bold
                                 :foreground ,monokai-orange))
       (,monokai-256-class (:inherit bold
-                                     :foreground ,monokai-256-orange))))
+                                    :foreground ,monokai-256-orange))))
 
    ;; auto-complete
    `(ac-candidate-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-blue))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-blue))))
+                                       :foreground ,monokai-256-blue))))
 
    `(ac-selection-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(ac-candidate-mouse-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(ac-completion-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :underline t))))
+                                       :underline t))))
 
    `(ac-gtags-candidate-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-blue))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-blue))))
+                                       :foreground ,monokai-256-blue))))
 
    `(ac-gtags-selection-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(ac-yasnippet-candidate-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-yellow))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-yellow))))
+                                       :foreground ,monokai-256-yellow))))
 
    `(ac-yasnippet-selection-face
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    ;; auto highlight symbol
    `(ahs-definition-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-blue))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-blue))))
+                                       :background ,monokai-256-blue))))
 
    `(ahs-edit-mode-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-highlight))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-highlight))))
+                                       :background ,monokai-256-highlight))))
 
    `(ahs-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-yellow))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :background unspecified))))
+                                       :background unspecified))))
 
    `(ahs-plugin-bod-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-violet ))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-cyan ))))
+                                       :background ,monokai-256-cyan ))))
 
    `(ahs-plugin-defalt-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-orange))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-orange))))
+                                       :background ,monokai-256-orange))))
 
    `(ahs-plugin-whole-buffer-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-green))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-green))))
+                                       :background ,monokai-256-green))))
 
    `(ahs-warning-face
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; android mode
    `(android-mode-debug-face
@@ -1071,7 +1071,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(android-mode-info-face
      ((,monokai-class (:foreground ,monokai-foreground))
@@ -1090,33 +1090,43 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; bm
    `(bm-face
      ((,monokai-class (:background ,monokai-yellow-lc
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow-lc
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(bm-fringe-face
      ((,monokai-class (:background ,monokai-yellow-lc
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow-lc
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(bm-fringe-persistent-face
      ((,monokai-class (:background ,monokai-green-lc
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-green-lc
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(bm-persistent-face
      ((,monokai-class (:background ,monokai-green-lc
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-green-lc
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
+   ;; centaur-tabs
+   `(centaur-tabs-default ((t (:background ,monokai-background :foreground ,monokai-gray-d :box nil))))
+   `(centaur-tabs-selected ((t (:background ,monokai-emphasis :foreground ,monokai-comments :box nil))))
+   `(centaur-tabs-unselected ((t (:background ,monokai-background :foreground ,monokai-comments :box nil))))
+   `(centaur-tabs-selected-modified ((t (:background ,monokai-emphasis :foreground ,monokai-orange :box nil))))
+   `(centaur-tabs-unselected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
+   `(centaur-tabs-active-bar-face ((t (:background ,monokai-yellow :box nil))))
+   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-yellow :box nil))))
+   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-yellow :box nil))))
+   
    ;; calfw
    `(cfw:face-day-title
      ((,monokai-class (:background ,monokai-highlight-line))
@@ -1126,7 +1136,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit cfw:face-day-title
                                 :foreground ,monokai-yellow))
       (,monokai-256-class (:inherit cfw:face-day-title
-                                     :foreground ,monokai-256-yellow))))
+                                    :foreground ,monokai-256-yellow))))
 
    `(cfw:face-default-content
      ((,monokai-class (:foreground ,monokai-green))
@@ -1136,13 +1146,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit cfw:face-day-title
                                 :weight bold))
       (,monokai-256-class (:inherit cfw:face-day-title
-                                     :weight bold))))
+                                    :weight bold))))
 
    `(cfw:face-disable
      ((,monokai-class (:inherit cfw:face-day-title
                                 :foreground ,monokai-comments))
       (,monokai-256-class (:inherit cfw:face-day-title
-                                     :foreground ,monokai-256-comments))))
+                                    :foreground ,monokai-256-comments))))
 
    `(cfw:face-grid
      ((,monokai-class (:foreground ,monokai-comments))
@@ -1153,16 +1163,16 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-blue-lc
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue-hc
-                                        :background ,monokai-256-blue-lc
-                                        :weight bold))))
+                                       :background ,monokai-256-blue-lc
+                                       :weight bold))))
 
    `(cfw:face-holiday
      ((,monokai-class (:background nil
                                    :foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:background nil
-                                        :foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :foreground ,monokai-256-red
+                                       :weight bold))))
 
    `(cfw:face-periods
      ((,monokai-class (:foreground ,monokai-magenta))
@@ -1172,21 +1182,21 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-magenta-lc
                                    :foreground ,monokai-magenta-hc))
       (,monokai-256-class (:background ,monokai-256-magenta-lc
-                                        :foreground ,monokai-256-magenta-hc))))
+                                       :foreground ,monokai-256-magenta-hc))))
 
    `(cfw:face-saturday
      ((,monokai-class (:foreground ,monokai-cyan-hc
                                    :background ,monokai-cyan-lc))
       (,monokai-256-class (:foreground ,monokai-256-cyan-hc
-                                        :background ,monokai-256-cyan-lc))))
+                                       :background ,monokai-256-cyan-lc))))
 
    `(cfw:face-sunday
      ((,monokai-class (:foreground ,monokai-red-hc
                                    :background ,monokai-red-lc
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red-hc
-                                        :background ,monokai-256-red-lc
-                                        :weight bold))))
+                                       :background ,monokai-256-red-lc
+                                       :weight bold))))
 
    `(cfw:face-title
      ((,monokai-class (:inherit ,monokai-pitch
@@ -1194,47 +1204,47 @@ Also affects 'linum-mode' background."
                                 :weight bold
                                 :height ,monokai-height-plus-4))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-yellow
-                                     :weight bold
-                                     :height ,monokai-height-plus-4))))
+                                    :foreground ,monokai-256-yellow
+                                    :weight bold
+                                    :height ,monokai-height-plus-4))))
 
    `(cfw:face-today
      ((,monokai-class (:weight bold
                                :background ,monokai-highlight-line
                                :foreground nil))
       (,monokai-256-class (:weight bold
-                                    :background ,monokai-256-highlight-line
-                                    :foreground nil))))
+                                   :background ,monokai-256-highlight-line
+                                   :foreground nil))))
 
    `(cfw:face-today-title
      ((,monokai-class (:background ,monokai-yellow-lc
                                    :foreground ,monokai-yellow-hc
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-yellow-lc
-                                        :foreground ,monokai-256-yellow-hc
-                                        :weight bold))))
+                                       :foreground ,monokai-256-yellow-hc
+                                       :weight bold))))
 
    `(cfw:face-toolbar
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(cfw:face-toolbar-button-off
      ((,monokai-class (:background ,monokai-yellow-lc
                                    :foreground ,monokai-yellow-hc
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-yellow-lc
-                                        :foreground ,monokai-256-yellow-hc
-                                        :weight bold))))
+                                       :foreground ,monokai-256-yellow-hc
+                                       :weight bold))))
 
    `(cfw:face-toolbar-button-on
      ((,monokai-class (:background ,monokai-yellow-hc
                                    :foreground ,monokai-yellow-lc
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-yellow-hc
-                                        :foreground ,monokai-256-yellow-lc
-                                        :weight bold))))
+                                       :foreground ,monokai-256-yellow-lc
+                                       :weight bold))))
 
    ;; cider
    `(cider-enlightened
@@ -1242,8 +1252,8 @@ Also affects 'linum-mode' background."
                                    :background nil
                                    :box (:color ,monokai-yellow :line-width -1 :style nil)))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background nil
-                                        :box (:color ,monokai-256-yellow :line-width -1 :style nil))) ))
+                                       :background nil
+                                       :box (:color ,monokai-256-yellow :line-width -1 :style nil))) ))
 
    `(cider-enlightened-local
      ((,monokai-class (:foreground ,monokai-yellow))
@@ -1254,34 +1264,34 @@ Also affects 'linum-mode' background."
                                    :background nil
                                    :box (:color ,monokai-violet :line-width -1 :style nil)))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :background nil
-                                        :box (:color ,monokai-256-violet :line-width -1 :style nil)))))
+                                       :background nil
+                                       :box (:color ,monokai-256-violet :line-width -1 :style nil)))))
 
    `(cider-result-overlay-face
      ((,monokai-class (:foreground ,monokai-blue
                                    :background nil
                                    :box (:color ,monokai-blue :line-width -1 :style nil)))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background nil
-                                        :box (:color ,monokai-256-blue :line-width -1 :style nil)))))
+                                       :background nil
+                                       :box (:color ,monokai-256-blue :line-width -1 :style nil)))))
 
    `(cider-test-error-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-orange))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-orange))))
+                                       :background ,monokai-256-orange))))
 
    `(cider-test-failure-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-red))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-red))))
+                                       :background ,monokai-256-red))))
 
    `(cider-test-success-face
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-green))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-green))))
+                                       :background ,monokai-256-green))))
 
    `(cider-traced-face
      ((,monokai-class :box (:color ,monokai-blue :line-width -1 :style nil))
@@ -1293,69 +1303,69 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
    `(clojure-test-error-face
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight bold
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
    `(clojure-test-success-face
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
    ;; company-mode
    `(company-tooltip
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-emphasis))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis))))
+                                       :foreground ,monokai-256-emphasis))))
 
    `(company-tooltip-selection
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(company-tooltip-mouse
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(company-tooltip-common
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline t))))
+                                       :underline t))))
 
    `(company-tooltip-common-selection
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-blue
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-blue
-                                        :underline t))))
+                                       :background ,monokai-256-blue
+                                       :underline t))))
 
    `(company-preview
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-emphasis))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis))))
+                                       :foreground ,monokai-256-emphasis))))
 
    `(company-preview-common
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline t))))
+                                       :underline t))))
 
    `(company-scrollbar-bg
      ((,monokai-class (:background ,monokai-gray))
@@ -1369,127 +1379,127 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-green))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-green))))
+                                       :foreground ,monokai-256-green))))
 
    `(company-template-field
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-blue))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-blue))))
+                                       :foreground ,monokai-256-blue))))
 
    ;; compilation
    `(compilation-column-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-column-number
      ((,monokai-class (:inherit font-lock-doc-face
                                 :foreground ,monokai-cyan
                                 :underline nil))
       (,monokai-256-class (:inherit font-lock-doc-face
-                                     :foreground ,monokai-256-cyan
-                                     :underline nil))))
+                                    :foreground ,monokai-256-cyan
+                                    :underline nil))))
 
    `(compilation-enter-directory-face
      ((,monokai-class (:foreground ,monokai-green
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-error
      ((,monokai-class (:inherit error
                                 :underline nil))
       (,monokai-256-class (:inherit error
-                                     :underline nil))))
+                                    :underline nil))))
 
    `(compilation-error-face
      ((,monokai-class (:foreground ,monokai-red
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-face
      ((,monokai-class (:foreground ,monokai-foreground
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-info
      ((,monokai-class (:foreground ,monokai-comments
                                    :underline nil
                                    :bold nil))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :underline nil
-                                        :bold nil))))
+                                       :underline nil
+                                       :bold nil))))
 
    `(compilation-info-face
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-leave-directory-face
      ((,monokai-class (:foreground ,monokai-green
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-line-face
      ((,monokai-class (:foreground ,monokai-green
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-line-number
      ((,monokai-class (:foreground ,monokai-green
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :underline nil))))
+                                       :underline nil))))
 
    `(compilation-warning
      ((,monokai-class (:inherit warning
                                 :underline nil))
       (,monokai-256-class (:inherit warning
-                                     :underline nil))))
+                                    :underline nil))))
 
    `(compilation-warning-face
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal
-                                        :underline nil))))
+                                       :weight normal
+                                       :underline nil))))
 
    `(compilation-mode-line-exit
      ((,monokai-class (:inherit compilation-info
                                 :foreground ,monokai-green
                                 :weight bold))
       (,monokai-256-class (:inherit compilation-info
-                                     :foreground ,monokai-256-green
-                                     :weight bold))))
+                                    :foreground ,monokai-256-green
+                                    :weight bold))))
 
    `(compilation-mode-line-fail
      ((,monokai-class (:inherit compilation-error
                                 :foreground ,monokai-red
                                 :weight bold))
       (,monokai-256-class (:inherit compilation-error
-                                     :foreground ,monokai-256-red
-                                     :weight bold))))
+                                    :foreground ,monokai-256-red
+                                    :weight bold))))
 
    `(compilation-mode-line-run
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; CSCOPE
    `(cscope-file-face
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(cscope-function-face
      ((,monokai-class (:foreground ,monokai-blue))
@@ -1507,7 +1517,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    ;; ctable
    `(ctbl:face-cell-select
@@ -1516,36 +1526,36 @@ Also affects 'linum-mode' background."
                                    :underline ,monokai-emphasis
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :underline ,monokai-256-emphasis
-                                        :weight bold))))
+                                       :foreground ,monokai-256-emphasis
+                                       :underline ,monokai-256-emphasis
+                                       :weight bold))))
 
    `(ctbl:face-continue-bar
      ((,monokai-class (:background ,monokai-gray
                                    :foreground ,monokai-yellow))
       (,monokai-256-class (:background ,monokai-256-gray
-                                        :foreground ,monokai-256-yellow))))
+                                       :foreground ,monokai-256-yellow))))
 
    `(ctbl:face-row-select
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground
                                    :underline t))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground
-                                        :underline t))))
+                                       :foreground ,monokai-256-foreground
+                                       :underline t))))
 
    ;; coffee
    `(coffee-mode-class-name
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(coffee-mode-function-param
      ((,monokai-class (:foreground ,monokai-violet
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :slant italic))))
+                                       :slant italic))))
 
    ;; custom
    `(custom-face-tag
@@ -1554,17 +1564,17 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-violet
                                 :weight bold))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :height ,monokai-height-plus-3
-                                     :foreground ,monokai-256-violet
-                                     :weight bold))))
+                                    :height ,monokai-height-plus-3
+                                    :foreground ,monokai-256-violet
+                                    :weight bold))))
 
    `(custom-variable-tag
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-cyan
                                 :height ,monokai-height-plus-3))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-cyan
-                                     :height ,monokai-height-plus-3))))
+                                    :foreground ,monokai-256-cyan
+                                    :height ,monokai-height-plus-3))))
 
    `(custom-comment-tag
      ((,monokai-class (:foreground ,monokai-comments))
@@ -1575,16 +1585,16 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-blue
                                 :height ,monokai-height-plus-3))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-blue
-                                     :height ,monokai-height-plus-3))))
+                                    :foreground ,monokai-256-blue
+                                    :height ,monokai-height-plus-3))))
 
    `(custom-group-tag-1
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-red
                                 :height ,monokai-height-plus-3))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-red
-                                     :height ,monokai-height-plus-3))))
+                                    :foreground ,monokai-256-red
+                                    :height ,monokai-height-plus-3))))
 
    `(custom-state
      ((,monokai-class (:foreground ,monokai-green))
@@ -1595,19 +1605,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(diff-changed
      ((,monokai-class (:foreground ,monokai-blue
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(diff-removed
      ((,monokai-class (:foreground ,monokai-red
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(diff-header
      ((,monokai-class (:background ,monokai-background))
@@ -1618,51 +1628,51 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-foreground
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground
-                                        :weight bold))))
+                                       :foreground ,monokai-256-foreground
+                                       :weight bold))))
 
    `(diff-refine-added
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-green))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-green))))
+                                       :background ,monokai-256-green))))
 
    `(diff-refine-change
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-blue))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-blue))))
+                                       :background ,monokai-256-blue))))
 
    `(diff-refine-removed
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-red))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-red))))
+                                       :background ,monokai-256-red))))
 
    ;; diff-hl
    `(diff-hl-change
      ((,monokai-class (:background ,monokai-yellow-hc-alt
                                    :foreground ,monokai-yellow-hc-alt))
       (,monokai-256-class (:background ,monokai-256-yellow-hc
-                                        :foreground ,monokai-256-yellow-hc))))
+                                       :foreground ,monokai-256-yellow-hc))))
 
    `(diff-hl-delete
      ((,monokai-class (:background ,monokai-red-hc-alt
                                    :foreground ,monokai-red-hc-alt))
       (,monokai-256-class (:background ,monokai-256-red-hc
-                                        :foreground ,monokai-256-red-hc))))
+                                       :foreground ,monokai-256-red-hc))))
 
    `(diff-hl-insert
      ((,monokai-class (:background ,monokai-green-hc-alt
                                    :foreground ,monokai-green-hc-alt))
       (,monokai-256-class (:background ,monokai-256-green-hc
-                                        :foreground ,monokai-256-green-hc))))
+                                       :foreground ,monokai-256-green-hc))))
 
    `(diff-hl-unknown
      ((,monokai-class (:background ,monokai-violet-hc
                                    :foreground ,monokai-violet-hc))
       (,monokai-256-class (:background ,monokai-256-violet-hc
-                                        :foreground ,monokai-256-violet-hc))))
+                                       :foreground ,monokai-256-violet-hc))))
 
    ;; ediff
    `(ediff-fine-diff-A
@@ -1693,37 +1703,37 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-foreground-lc ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-foreground-lc ))))
+                                       :foreground ,monokai-256-foreground-lc ))))
 
    `(ediff-odd-diff-A
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-foreground-hc ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-foreground-hc ))))
+                                       :foreground ,monokai-256-foreground-hc ))))
 
    `(ediff-even-diff-B
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-foreground-hc ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-foreground-hc ))))
+                                       :foreground ,monokai-256-foreground-hc ))))
 
    `(ediff-odd-diff-B
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-foreground-lc ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-foreground-lc ))))
+                                       :foreground ,monokai-256-foreground-lc ))))
 
    `(ediff-even-diff-C
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-foreground ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-foreground ))))
+                                       :foreground ,monokai-256-foreground ))))
 
    `(ediff-odd-diff-C
      ((,monokai-class (:background ,monokai-comments
                                    :foreground ,monokai-background ))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-background ))))
+                                       :foreground ,monokai-256-background ))))
 
    ;; edts
    `(edts-face-error-line
@@ -1738,9 +1748,9 @@ Also affects 'linum-mode' background."
        (:underline (:style line :color ,monokai-256-red)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-red-hc
-                                        :background ,monokai-256-red-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-red-lc
+                                       :weight bold
+                                       :underline t))))
 
    `(edts-face-warning-line
      ((,(append '((supports :underline (:style line))) monokai-class)
@@ -1754,37 +1764,37 @@ Also affects 'linum-mode' background."
        (:underline (:style line :color ,monokai-256-yellow)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-yellow-hc
-                                        :background ,monokai-256-yellow-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-yellow-lc
+                                       :weight bold
+                                       :underline t))))
 
    `(edts-face-error-fringe-bitmap
      ((,monokai-class (:foreground ,monokai-red
                                    :background unspecified
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background unspecified
-                                        :weight bold))))
+                                       :background unspecified
+                                       :weight bold))))
 
    `(edts-face-warning-fringe-bitmap
      ((,monokai-class (:foreground ,monokai-yellow
                                    :background unspecified
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background unspecified
-                                        :weight bold))))
+                                       :background unspecified
+                                       :weight bold))))
 
    `(edts-face-error-mode-line
      ((,monokai-class (:background ,monokai-red
                                    :foreground unspecified))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground unspecified))))
+                                       :foreground unspecified))))
 
    `(edts-face-warning-mode-line
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground unspecified))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground unspecified))))
+                                       :foreground unspecified))))
 
 
    ;; elfeed
@@ -1860,9 +1870,9 @@ Also affects 'linum-mode' background."
        (:underline (:style wave :color ,monokai-256-red)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-red-hc
-                                        :background ,monokai-256-red-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-red-lc
+                                       :weight bold
+                                       :underline t))))
 
    `(erm-syn-warnline
      ((,(append '((supports :underline (:style wave))) monokai-class)
@@ -1876,9 +1886,9 @@ Also affects 'linum-mode' background."
        (:underline (:style wave :color ,monokai-256-orange)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-orange-hc
-                                        :background ,monokai-256-orange-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-orange-lc
+                                       :weight bold
+                                       :underline t))))
 
    ;; epc
    `(epc:face-title
@@ -1887,9 +1897,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :underline nil))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :underline nil))))
 
    ;; erc
    `(erc-action-face
@@ -1903,7 +1913,7 @@ Also affects 'linum-mode' background."
    `(erc-current-nick-face
      ((,monokai-class (:foreground ,monokai-blue :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(erc-dangerous-host-face
      ((,monokai-class (:inherit font-lock-warning-face))
@@ -1917,7 +1927,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit erc-default-face
                                 :background ,monokai-highlight))
       (,monokai-256-class (:inherit erc-default-face
-                                     :background ,monokai-256-highlight))))
+                                    :background ,monokai-256-highlight))))
 
    `(erc-direct-msg-face
      ((,monokai-class (:inherit erc-default-face))
@@ -1939,19 +1949,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(erc-nick-default-face
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(erc-my-nick-face
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(erc-nick-msg-face
      ((,monokai-class (:inherit erc-default-face))
@@ -1965,15 +1975,15 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(erc-prompt-face
      ((,monokai-class (:foreground ,monokai-orange
                                    :background ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :background ,monokai-256-background
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :weight bold))))
 
    `(erc-timestamp-face
      ((,monokai-class (:foreground ,monokai-green))
@@ -1987,13 +1997,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(eshell-ls-archive
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(eshell-ls-backup
      ((,monokai-class (:inherit font-lock-comment-face))
@@ -2007,13 +2017,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(eshell-ls-executable
      ((,monokai-class (:foreground ,monokai-green
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(eshell-ls-unreadable
      ((,monokai-class (:foreground ,monokai-foreground))
@@ -2031,13 +2041,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(eshell-ls-symlink
      ((,monokai-class (:foreground ,monokai-cyan
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    ;; evil-ex-substitute
    `(evil-ex-substitute-matches
@@ -2045,8 +2055,8 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-red-l
                                    :inherit italic))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-red-l
-                                        :inherit italic))))
+                                       :foreground ,monokai-256-red-l
+                                       :inherit italic))))
    `(evil-ex-substitute-replacement
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-green-l
@@ -2065,9 +2075,9 @@ Also affects 'linum-mode' background."
                                    :underline t
                                    :slant italic))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-orange
-                                        :underline t
-                                        :slant italic))))
+                                       :foreground ,monokai-256-orange
+                                       :underline t
+                                       :slant italic))))
 
    `(fic-face
      ((,monokai-class (:background ,monokai-background
@@ -2075,9 +2085,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :slant italic))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-orange
-                                        :weight normal
-                                        :slant italic))))
+                                       :foreground ,monokai-256-orange
+                                       :weight normal
+                                       :slant italic))))
 
    `(font-lock-fic-face
      ((,monokai-class (:background ,monokai-background
@@ -2085,9 +2095,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :slant italic))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-orange
-                                        :weight normal
-                                        :slant italic))))
+                                       :foreground ,monokai-256-orange
+                                       :weight normal
+                                       :slant italic))))
 
    ;; flx
    `(flx-highlight-face
@@ -2095,8 +2105,8 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight normal
-                                        :underline nil))))
+                                       :weight normal
+                                       :underline nil))))
 
    ;; flymake
    `(flymake-errline
@@ -2115,9 +2125,9 @@ Also affects 'linum-mode' background."
                    :foreground unspecified
                    :background unspecified))
       (,monokai-256-class (:foreground ,monokai-256-red-hc
-                                        :background ,monokai-256-red-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-red-lc
+                                       :weight bold
+                                       :underline t))))
 
    `(flymake-infoline
      ((,(append '((supports :underline (:style wave))) monokai-class)
@@ -2133,7 +2143,7 @@ Also affects 'linum-mode' background."
                    :foreground unspecified
                    :background unspecified))
       (,monokai-256-class (:foreground ,monokai-256-green-hc
-                                        :background ,monokai-256-green-lc))))
+                                       :background ,monokai-256-green-lc))))
 
    `(flymake-warnline
      ((,(append '((supports :underline (:style wave))) monokai-class)
@@ -2151,9 +2161,9 @@ Also affects 'linum-mode' background."
                    :foreground unspecified
                    :background unspecified))
       (,monokai-256-class (:foreground ,monokai-256-yellow-hc
-                                        :background ,monokai-256-yellow-lc
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-yellow-lc
+                                       :weight bold
+                                       :underline t))))
 
    ;; flycheck
    `(flycheck-error
@@ -2166,9 +2176,9 @@ Also affects 'linum-mode' background."
       (,(append '((supports :underline (:style line))) monokai-256-class )
        (:underline (:style line :color ,monokai-256-red)))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-background
+                                       :weight bold
+                                       :underline t))))
 
    `(flycheck-warning
      ((,(append '((supports :underline (:style line))) monokai-class)
@@ -2180,9 +2190,9 @@ Also affects 'linum-mode' background."
       (,(append '((supports :underline (:style line))) monokai-256-class )
        (:underline (:style line :color ,monokai-256-orange)))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :background ,monokai-256-background
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-background
+                                       :weight bold
+                                       :underline t))))
 
    `(flycheck-info
      ((,(append '((supports :underline (:style line))) monokai-class)
@@ -2194,33 +2204,33 @@ Also affects 'linum-mode' background."
       (,(append '((supports :underline (:style line))) monokai-256-class )
        (:underline (:style line :color ,monokai-256-blue)))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background
-                                        :weight bold
-                                        :underline t))))
+                                       :background ,monokai-256-background
+                                       :weight bold
+                                       :underline t))))
 
    `(flycheck-fringe-error
      ((,monokai-class (:foreground ,monokai-red-l
                                    :background unspecified
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red-l
-                                        :background unspecified
-                                        :weight bold))))
+                                       :background unspecified
+                                       :weight bold))))
 
    `(flycheck-fringe-warning
      ((,monokai-class (:foreground ,monokai-orange-l
                                    :background unspecified
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange-l
-                                        :background unspecified
-                                        :weight bold))))
+                                       :background unspecified
+                                       :weight bold))))
 
    `(flycheck-fringe-info
      ((,monokai-class (:foreground ,monokai-blue-l
                                    :background unspecified
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue-l
-                                        :background unspecified
-                                        :weight bold))))
+                                       :background unspecified
+                                       :weight bold))))
 
    ;; flyspell
    `(flyspell-duplicate
@@ -2234,8 +2244,8 @@ Also affects 'linum-mode' background."
        (:underline (:style wave :color ,monokai-256-yellow)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
    `(flyspell-incorrect
      ((,(append '((supports :underline (:style wave))) monokai-class)
@@ -2248,8 +2258,8 @@ Also affects 'linum-mode' background."
        (:underline (:style wave :color ,monokai-256-red)
                    :inherit unspecified))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold
-                                        :underline t))))
+                                       :weight bold
+                                       :underline t))))
 
 
    ;; git-gutter
@@ -2258,51 +2268,51 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter:deleted
      ((,monokai-class (:background ,monokai-red
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter:modified
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter:unchanged
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    ;; git-gutter-fr
    `(git-gutter-fr:added
      ((,monokai-class (:foreground ,monokai-green
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(git-gutter-fr:deleted
      ((,monokai-class (:foreground ,monokai-red
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(git-gutter-fr:modified
      ((,monokai-class (:foreground ,monokai-blue
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    ;; git-gutter+ and git-gutter+-fr
    `(git-gutter+-added
@@ -2310,50 +2320,50 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter+-deleted
      ((,monokai-class (:background ,monokai-red
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter+-modified
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter+-unchanged
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-background
                                    :inherit bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-background
-                                        :inherit bold))))
+                                       :foreground ,monokai-256-background
+                                       :inherit bold))))
 
    `(git-gutter-fr+-added
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(git-gutter-fr+-deleted
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(git-gutter-fr+-modified
      ((,monokai-class (:foreground ,monokai-blue
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; git-timemachine
    `(git-timemachine-minibuffer-detail-face
@@ -2361,8 +2371,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-highlight-line
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-blue
-                                        :background ,monokai-256-highlight-line
-                                        :inherit bold))))
+                                       :background ,monokai-256-highlight-line
+                                       :inherit bold))))
 
    ;; guide-key
    `(guide-key/highlight-command-face
@@ -2382,7 +2392,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :inherit gnus-group-mail-1-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-mail-1-empty))))
+                                   :inherit gnus-group-mail-1-empty))))
 
    `(gnus-group-mail-1-empty
      ((,monokai-class (:inherit gnus-group-news-1-empty))
@@ -2392,7 +2402,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :inherit gnus-group-mail-2-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-mail-2-empty))))
+                                   :inherit gnus-group-mail-2-empty))))
 
    `(gnus-group-mail-2-empty
      ((,monokai-class (:inherit gnus-group-news-2-empty))
@@ -2402,7 +2412,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :inherit gnus-group-mail-3-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-mail-3-empty))))
+                                   :inherit gnus-group-mail-3-empty))))
 
    `(gnus-group-mail-3-empty
      ((,monokai-class (:inherit gnus-group-news-3-empty))
@@ -2412,7 +2422,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :inherit gnus-group-mail-low-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-mail-low-empty))))
+                                   :inherit gnus-group-mail-low-empty))))
 
    `(gnus-group-mail-low-empty
      ((,monokai-class (:inherit gnus-group-news-low-empty))
@@ -2422,43 +2432,43 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-1-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-1-empty))))
+                                   :inherit gnus-group-news-1-empty))))
 
    `(gnus-group-news-2
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-2-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-2-empty))))
+                                   :inherit gnus-group-news-2-empty))))
 
    `(gnus-group-news-3
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-3-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-3-empty))))
+                                   :inherit gnus-group-news-3-empty))))
 
    `(gnus-group-news-4
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-4-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-4-empty))))
+                                   :inherit gnus-group-news-4-empty))))
 
    `(gnus-group-news-5
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-5-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-5-empty))))
+                                   :inherit gnus-group-news-5-empty))))
 
    `(gnus-group-news-6
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-6-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-6-empty))))
+                                   :inherit gnus-group-news-6-empty))))
 
    `(gnus-group-news-low
      ((,monokai-class (:weight bold
                                :inherit gnus-group-news-low-empty))
       (,monokai-256-class (:weight bold
-                                    :inherit gnus-group-news-low-empty))))
+                                   :inherit gnus-group-news-low-empty))))
 
    `(gnus-header-content
      ((,monokai-class (:inherit message-header-other))
@@ -2488,25 +2498,25 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(gnus-summary-high-read
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(gnus-summary-high-ticked
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(gnus-summary-high-unread
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(gnus-summary-low-ancient
      ((,monokai-class (:foreground ,monokai-blue))
@@ -2544,7 +2554,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(gnus-cite-1
      ((,monokai-class (:foreground ,monokai-blue))
@@ -2626,7 +2636,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-foreground
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-foreground
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
 
    ;; helm
@@ -2683,8 +2693,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :inverse-video t))))
 
    `(helm-buffer-size
      ((,monokai-class (:foreground ,monokai-comments))
@@ -2695,8 +2705,8 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-emphasis
                                    :bold t))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :bold t))))
+                                       :foreground ,monokai-256-emphasis
+                                       :bold t))))
 
    `(helm-ff-directory
      ((,monokai-class (:foreground ,monokai-blue))
@@ -2710,21 +2720,21 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(helm-ff-invalid-symlink
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-orange
                                    :slant italic))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-orange
-                                        :slant italic))))
+                                       :foreground ,monokai-256-orange
+                                       :slant italic))))
 
    `(helm-ff-prefix
      ((,monokai-class (:background ,monokai-green
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(helm-ff-symlink
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -2734,7 +2744,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-cyan
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :underline t))))
+                                       :underline t))))
 
    `(helm-grep-finish
      ((,monokai-class (:foreground ,monokai-green))
@@ -2765,20 +2775,20 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-highlight-line
                                    :bold t))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background ,monokai-256-highlight-line
-                                        :bold t))))
+                                       :background ,monokai-256-highlight-line
+                                       :bold t))))
 
    `(helm-M-x-key
      ((,monokai-class (:foreground ,monokai-orange
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :underline t))))
+                                       :underline t))))
 
    `(helm-moccur-buffer
      ((,monokai-class (:foreground ,monokai-cyan
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :underline t))))
+                                       :underline t))))
 
    `(helm-match
      ((,monokai-class (:foreground ,monokai-green :inherit bold))
@@ -2793,16 +2803,16 @@ Also affects 'linum-mode' background."
                                    :inherit bold
                                    :underline nil))
       (,monokai-256-class (:background ,monokai-256-highlight
-                                        :inherit bold
-                                        :underline nil))))
+                                       :inherit bold
+                                       :underline nil))))
 
    `(helm-selection-line
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-emphasis
                                    :underline nil))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :underline nil))))
+                                       :foreground ,monokai-256-emphasis
+                                       :underline nil))))
 
    `(helm-separator
      ((,monokai-class (:foreground ,monokai-gray))
@@ -2813,8 +2823,8 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :underline nil))
       (,monokai-256-class (:background ,monokai-256-violet-l
-                                        :foreground ,monokai-256-background
-                                        :underline nil))))
+                                       :foreground ,monokai-256-background
+                                       :underline nil))))
 
    `(helm-swoop-target-line-face
      ((,monokai-class (:background ,monokai-highlight-line))
@@ -2840,7 +2850,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-magenta :bold t))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-magenta :bold t))))
+                                       :foreground ,monokai-256-magenta :bold t))))
 
    ;; helm-ls-git
    `(helm-ls-git-modified-not-staged-face
@@ -2884,59 +2894,59 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow-lc
                                    :background ,monokai-yellow-hc))
       (,monokai-256-class (:foreground ,monokai-256-yellow-lc
-                                        :background ,monokai-256-yellow-hc))))
+                                       :background ,monokai-256-yellow-hc))))
 
    `(hi-pink
      ((,monokai-class (:foreground ,monokai-magenta-lc
                                    :background ,monokai-magenta-hc))
       (,monokai-256-class (:foreground ,monokai-256-magenta-lc
-                                        :background ,monokai-256-magenta-hc))))
+                                       :background ,monokai-256-magenta-hc))))
 
    `(hi-green
      ((,monokai-class (:foreground ,monokai-green-lc
                                    :background ,monokai-green-hc))
       (,monokai-256-class (:foreground ,monokai-256-green-lc
-                                        :background ,monokai-256-green-hc))))
+                                       :background ,monokai-256-green-hc))))
 
    `(hi-blue
      ((,monokai-class (:foreground ,monokai-blue-lc
                                    :background ,monokai-blue-hc))
       (,monokai-256-class (:foreground ,monokai-256-blue-lc
-                                        :background ,monokai-256-blue-hc))))
+                                       :background ,monokai-256-blue-hc))))
 
    `(hi-black-b
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :weight bold))))
 
    `(hi-blue-b
      ((,monokai-class (:foreground ,monokai-blue-lc
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue-lc
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(hi-green-b
      ((,monokai-class (:foreground ,monokai-green-lc
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green-lc
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(hi-red-b
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                   :weight bold))))
+                                       :weight bold))))
 
    `(hi-black-hb
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :weight bold))))
 
    ;; highlight-changes
    `(highlight-changes
@@ -2947,7 +2957,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :underline t))))
+                                       :underline t))))
 
    ;; highlight-indentation
    `(highlight-indentation-face
@@ -2977,15 +2987,15 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(ido-only-match
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-yellow
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-yellow
-                                        :weight normal))))
+                                       :background ,monokai-256-yellow
+                                       :weight normal))))
 
    `(ido-subdir
      ((,monokai-class (:foreground ,monokai-blue))
@@ -2995,15 +3005,15 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold ))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold ))))
+                                       :weight bold ))))
 
    `(ido-indicator
      ((,monokai-class (:background ,monokai-red
                                    :foreground ,monokai-background
                                    :width condensed))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-background
-                                        :width condensed))))
+                                       :foreground ,monokai-256-background
+                                       :width condensed))))
 
    `(ido-virtual
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -3015,8 +3025,8 @@ Also affects 'linum-mode' background."
                                    :inherit bold
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :inherit bold
-                                        :underline t))))
+                                       :inherit bold
+                                       :underline t))))
 
    `(info-menu
      ((,monokai-class (:foreground ,monokai-blue))
@@ -3026,7 +3036,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet
                                    :inherit bold))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :inherit bold))))
+                                       :inherit bold))))
 
    `(info-quoted-name
      ((,monokai-class (:foreground ,monokai-orange))
@@ -3037,8 +3047,8 @@ Also affects 'linum-mode' background."
                                    :underline t
                                    :inherit bold))
       (,monokai-256-class (:background nil
-                                        :underline t
-                                        :inherit bold))))
+                                       :underline t
+                                       :inherit bold))))
 
    `(info-string
      ((,monokai-class (:foreground ,monokai-yellow))
@@ -3073,19 +3083,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :underline t))))
+                                       :underline t))))
 
    `(ivy-minibuffer-match-face-3
      ((,monokai-class (:foreground ,monokai-green
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :underline t))))
+                                       :underline t))))
 
    `(ivy-minibuffer-match-face-4
      ((,monokai-class (:foreground ,monokai-yellow
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :underline t))))
+                                       :underline t))))
 
    `(ivy-remote
      ((,monokai-class (:foreground ,monokai-blue))
@@ -3111,37 +3121,37 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :foreground ,monokai-red))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-red))))
+                                   :foreground ,monokai-256-red))))
 
    `(jabber-activity-personal-face
      ((,monokai-class (:weight bold
                                :foreground ,monokai-blue))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-blue))))
+                                   :foreground ,monokai-256-blue))))
 
    `(jabber-chat-error
      ((,monokai-class (:weight bold
                                :foreground ,monokai-red))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-red))))
+                                   :foreground ,monokai-256-red))))
 
    `(jabber-chat-prompt-foreign
      ((,monokai-class (:weight bold
                                :foreground ,monokai-red))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-red))))
+                                   :foreground ,monokai-256-red))))
 
    `(jabber-chat-prompt-local
      ((,monokai-class (:weight bold
                                :foreground ,monokai-blue))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-blue))))
+                                   :foreground ,monokai-256-blue))))
 
    `(jabber-chat-prompt-system
      ((,monokai-class (:weight bold
                                :foreground ,monokai-green))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-green))))
+                                   :foreground ,monokai-256-green))))
 
    `(jabber-chat-text-foreign
      ((,monokai-class (:foreground ,monokai-comments))
@@ -3155,33 +3165,33 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:underline t
                                   :foreground ,monokai-green))
       (,monokai-256-class (:underline t
-                                       :foreground ,monokai-256-green))))
+                                      :foreground ,monokai-256-green))))
 
    `(jabber-roster-user-away
      ((,monokai-class (:slant italic
                               :foreground ,monokai-green))
       (,monokai-256-class (:slant italic
-                                   :foreground ,monokai-256-green))))
+                                  :foreground ,monokai-256-green))))
 
    `(jabber-roster-user-chatty
      ((,monokai-class (:weight bold
                                :foreground ,monokai-orange))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-orange))))
+                                   :foreground ,monokai-256-orange))))
 
    `(jabber-roster-user-dnd
      ((,monokai-class (:slant italic
                               :foreground ,monokai-red))
       (,monokai-256-class (:slant italic
-                                   :foreground ,monokai-256-red))))
+                                  :foreground ,monokai-256-red))))
 
    `(jabber-roster-user-error
      ((,monokai-class (:weight light
                                :slant italic
                                :foreground ,monokai-red))
       (,monokai-256-class (:weight light
-                                    :slant italic
-                                    :foreground ,monokai-256-red))))
+                                   :slant italic
+                                   :foreground ,monokai-256-red))))
 
    `(jabber-roster-user-offline
      ((,monokai-class (:foreground ,monokai-comments))
@@ -3191,13 +3201,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:weight bold
                                :foreground ,monokai-blue))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-blue))))
+                                   :foreground ,monokai-256-blue))))
 
    `(jabber-roster-user-xa
      ((,monokai-class (:slant italic
                               :foreground ,monokai-magenta))
       (,monokai-256-class (:slant italic
-                                   :foreground ,monokai-256-magenta))))
+                                  :foreground ,monokai-256-magenta))))
 
    ;; js2-mode colors
    `(js2-error
@@ -3272,9 +3282,9 @@ Also affects 'linum-mode' background."
                                    :inherit default
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-line-number
-                                        :background ,monokai-256-fringe-bg
-                                        :inherit default
-                                        :underline nil))))
+                                       :background ,monokai-256-fringe-bg
+                                       :inherit default
+                                       :underline nil))))
 
    ;; line-number (>= Emacs26)
    `(line-number
@@ -3283,18 +3293,18 @@ Also affects 'linum-mode' background."
                                    :inherit default
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-line-number
-                                        :background ,monokai-256-fringe-bg
-                                        :inherit default
-                                        :underline nil))))
+                                       :background ,monokai-256-fringe-bg
+                                       :inherit default
+                                       :underline nil))))
    `(line-number-current-line
      ((,monokai-class (:foreground ,monokai-foreground
                                    :background ,monokai-fringe-bg
                                    :inherit default
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :background ,monokai-256-fringe-bg
-                                        :inherit default
-                                        :underline nil))))
+                                       :background ,monokai-256-fringe-bg
+                                       :inherit default
+                                       :underline nil))))
 
    ;; linum-relative-current-face
    `(linum-relative-current-face
@@ -3302,8 +3312,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-highlight-line
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-line-number
-                                        :background ,monokai-256-highlight-line
-                                        :underline nil))))
+                                       :background ,monokai-256-highlight-line
+                                       :underline nil))))
 
    ;; lsp-mode
    `(lsp-ui-doc-header
@@ -3331,7 +3341,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-cyan
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; magit
    `(magit-bisect-good
@@ -3356,7 +3366,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit magit-diff-file-heading-highlight
                                 :foreground ,monokai-orange-d))
       (,monokai-256-class (:inherit magit-diff-file-heading-highlight
-                                   :foreground ,monokai-256-orange-d))))
+                                    :foreground ,monokai-256-orange-d))))
 
    `(magit-diff-hunk-heading
      ((,monokai-class (:foreground ,monokai-gray-d
@@ -3388,7 +3398,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(magit-diff-removed
      ((,monokai-class (:foreground ,monokai-red
@@ -3410,13 +3420,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :background ,monokai-highlight-alt))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-highlight-alt))))
+                                       :background ,monokai-256-highlight-alt))))
 
    `(magit-diff-removed-highlight
      ((,monokai-class (:foreground ,monokai-red
                                    :background ,monokai-highlight-alt))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-highlight-alt))))
+                                       :background ,monokai-256-highlight-alt))))
 
    `(magit-diff-base-highlight
      ((,monokai-class (:foreground ,monokai-yellow
@@ -3599,7 +3609,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(Man-reverse
      ((,monokai-class (:foreground ,monokai-orange))
@@ -3614,7 +3624,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(monky-diff-add
      ((,monokai-class (:foreground ,monokai-green))
@@ -3633,25 +3643,25 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit markdown-header-face
                                 :height ,monokai-height-plus-4))
       (,monokai-256-class (:inherit markdown-header-face
-                                     :height ,monokai-height-plus-4))))
+                                    :height ,monokai-height-plus-4))))
 
    `(markdown-header-face-2
      ((,monokai-class (:inherit markdown-header-face
                                 :height ,monokai-height-plus-3))
       (,monokai-256-class (:inherit markdown-header-face
-                                     :height ,monokai-height-plus-3))))
+                                    :height ,monokai-height-plus-3))))
 
    `(markdown-header-face-3
      ((,monokai-class (:inherit markdown-header-face
                                 :height ,monokai-height-plus-2))
       (,monokai-256-class (:inherit markdown-header-face
-                                     :height ,monokai-height-plus-2))))
+                                    :height ,monokai-height-plus-2))))
 
    `(markdown-header-face-4
      ((,monokai-class (:inherit markdown-header-face
                                 :height ,monokai-height-plus-1))
       (,monokai-256-class (:inherit markdown-header-face
-                                     :height ,monokai-height-plus-1))))
+                                    :height ,monokai-height-plus-1))))
 
    `(markdown-header-face-5
      ((,monokai-class (:inherit markdown-header-face))
@@ -3674,31 +3684,31 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(message-header-to
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(message-header-cc
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(message-header-newsgroups
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(message-header-subject
      ((,monokai-class (:foreground ,monokai-cyan
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(message-header-xheader
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -3708,13 +3718,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(message-separator
      ((,monokai-class (:foreground ,monokai-comments
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :slant italic))))
+                                       :slant italic))))
 
    ;; mew
    `(mew-face-header-subject
@@ -3749,7 +3759,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(mew-face-header-warning
      ((,monokai-class (:foreground ,monokai-red))
@@ -3771,7 +3781,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :slant italic))))
+                                       :slant italic))))
 
    `(mew-face-body-cite1
      ((,monokai-class (:foreground ,monokai-green))
@@ -3893,14 +3903,14 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-background
-                                        :slant italic))))
+                                       :background ,monokai-256-background
+                                       :slant italic))))
 
    `(moccur-edit-face
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(moccur-edit-file-face
      ((,monokai-class (:background ,monokai-highlight-line))
@@ -3915,24 +3925,24 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-emphasis
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :weight bold))))
+                                       :foreground ,monokai-256-emphasis
+                                       :weight bold))))
 
    `(search-buffers-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-emphasis
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :weight bold))))
+                                       :foreground ,monokai-256-emphasis
+                                       :weight bold))))
 
    `(search-buffers-header-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :foreground ,monokai-256-yellow
+                                       :weight bold))))
 
    ;; mu4e
    `(mu4e-cited-1-face
@@ -3940,76 +3950,76 @@ Also affects 'linum-mode' background."
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-2-face
      ((,monokai-class (:foreground ,monokai-blue
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-3-face
      ((,monokai-class (:foreground ,monokai-orange
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-4-face
      ((,monokai-class (:foreground ,monokai-yellow
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-5-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-6-face
      ((,monokai-class (:foreground ,monokai-green
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-cited-7-face
      ((,monokai-class (:foreground ,monokai-blue
                                    :slant italic
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :slant italic
-                                        :weight normal))))
+                                       :slant italic
+                                       :weight normal))))
 
    `(mu4e-flagged-face
      ((,monokai-class (:foreground ,monokai-magenta
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(mu4e-view-url-number-face
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(mu4e-warning-face
      ((,monokai-class (:foreground ,monokai-red
                                    :slant normal
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :slant normal
-                                        :weight bold))))
+                                       :slant normal
+                                       :weight bold))))
 
    `(mu4e-header-highlight-face
      ((,monokai-class (:inherit unspecified
@@ -4018,10 +4028,10 @@ Also affects 'linum-mode' background."
                                 :underline ,monokai-emphasis
                                 :weight normal))
       (,monokai-256-class (:inherit unspecified
-                                     :foreground unspecified
-                                     :background ,monokai-256-highlight-line
-                                     :underline ,monokai-256-emphasis
-                                     :weight normal))))
+                                    :foreground unspecified
+                                    :background ,monokai-256-highlight-line
+                                    :underline ,monokai-256-emphasis
+                                    :weight normal))))
 
 
    `(mu4e-draft-face
@@ -4036,7 +4046,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit font-lock-builtin-face
                                 :weight normal))
       (,monokai-256-class (:inherit font-lock-builtin-face
-                                     :weight normal))))
+                                    :weight normal))))
 
    `(mu4e-header-face
      ((,monokai-class (:inherit default))
@@ -4054,77 +4064,77 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:inherit font-lock-pseudo-keyword-face
                                 :weight bold))
       (,monokai-256-class (:inherit font-lock-pseudo-keyword-face
-                                     :weight bold))))
+                                    :weight bold))))
 
    `(mu4e-moved-face
      ((,monokai-class (:inherit font-lock-comment-face
                                 :slant italic))
       (,monokai-256-class (:inherit font-lock-comment-face
-                                     :slant italic))))
+                                    :slant italic))))
 
    `(mu4e-ok-face
      ((,monokai-class (:inherit font-lock-comment-face
                                 :slant normal
                                 :weight bold))
       (,monokai-256-class (:inherit font-lock-comment-face
-                                     :slant normal
-                                     :weight bold))))
+                                    :slant normal
+                                    :weight bold))))
 
    `(mu4e-replied-face
      ((,monokai-class (:inherit font-lock-builtin-face
                                 :weight normal))
       (,monokai-256-class (:inherit font-lock-builtin-face
-                                     :weight normal))))
+                                    :weight normal))))
 
    `(mu4e-system-face
      ((,monokai-class (:inherit font-lock-comment-face
                                 :slant italic))
       (,monokai-256-class (:inherit font-lock-comment-face
-                                     :slant italic))))
+                                    :slant italic))))
 
    `(mu4e-title-face
      ((,monokai-class (:inherit font-lock-type-face
                                 :weight bold))
       (,monokai-256-class (:inherit font-lock-type-face
-                                     :weight bold))))
+                                    :weight bold))))
 
    `(mu4e-trashed-face
      ((,monokai-class (:inherit font-lock-comment-face
                                 :strike-through t))
       (,monokai-256-class (:inherit font-lock-comment-face
-                                     :strike-through t))))
+                                    :strike-through t))))
 
    `(mu4e-unread-face
      ((,monokai-class (:inherit font-lock-keyword-face
                                 :weight bold))
       (,monokai-256-class (:inherit font-lock-keyword-face
-                                     :weight bold))))
+                                    :weight bold))))
 
    `(mu4e-view-attach-number-face
      ((,monokai-class (:inherit font-lock-variable-name-face
                                 :weight bold))
       (,monokai-256-class (:inherit font-lock-variable-name-face
-                                     :weight bold))))
+                                    :weight bold))))
 
    `(mu4e-view-contact-face
      ((,monokai-class (:foreground ,monokai-foreground
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(mu4e-view-header-key-face
      ((,monokai-class (:inherit message-header-name
                                 :weight normal))
       (,monokai-256-class (:inherit message-header-name
-                                     :weight normal))))
+                                    :weight normal))))
 
    `(mu4e-view-header-value-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :weight normal
                                    :slant normal))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :weight normal
-                                        :slant normal))))
+                                       :weight normal
+                                       :slant normal))))
 
    `(mu4e-view-link-face
      ((,monokai-class (:inherit link))
@@ -4135,8 +4145,8 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight normal
-                                        :underline nil))))
+                                       :weight normal
+                                       :underline nil))))
 
    ;; mumamo
    `(mumamo-background-chunk-submode1
@@ -4179,26 +4189,26 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :weight bold))))
 
 
    `(neo-header-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(neo-root-dir-face
      ((,monokai-class (:foreground ,monokai-green
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(neo-dir-link-face
      ((,monokai-class (:foreground ,monokai-blue))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(neo-file-link-face
      ((,monokai-class (:foreground ,monokai-foreground))
@@ -4220,7 +4230,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :slant italic))))
+                                       :slant italic))))
 
    `(neo-vc-up-to-date-face
      ((,monokai-class (:foreground ,monokai-comments))
@@ -4242,7 +4252,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :background ,monokai-comments))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-comments))))
+                                       :background ,monokai-256-comments))))
 
    `(neo-vc-added-face
      ((,monokai-class (:foreground ,monokai-green))
@@ -4273,7 +4283,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue-hc
                                    :background ,monokai-blue-lc))
       (,monokai-256-class (:foreground ,monokai-256-blue-hc
-                                        :background ,monokai-256-blue-lc))))
+                                       :background ,monokai-256-blue-lc))))
 
    `(markup-verbatim-face
      ((,monokai-class (:background ,monokai-orange-lc))
@@ -4283,7 +4293,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet-hc
                                    :background ,monokai-violet-lc))
       (,monokai-256-class (:foreground ,monokai-256-violet-hc
-                                        :background ,monokai-256-violet-lc))))
+                                       :background ,monokai-256-violet-lc))))
 
    `(markup-replacement-face
      ((,monokai-class (:foreground ,monokai-violet))
@@ -4293,7 +4303,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet-hc
                                    :background ,monokai-violet-lc))
       (,monokai-256-class (:foreground ,monokai-256-violet-hc
-                                        :background ,monokai-256-violet-lc))))
+                                       :background ,monokai-256-violet-lc))))
 
    `(markup-gen-face
      ((,monokai-class (:foreground ,monokai-blue))
@@ -4314,13 +4324,13 @@ Also affects 'linum-mode' background."
                                    :underline nil
                                    :box (:line-width 2 :color ,monokai-background)))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-highlight-line
-                                        :weight bold
-                                        :slant normal
-                                        :inverse-video nil
-                                        :height ,monokai-height-plus-1
-                                        :underline nil
-                                        :box (:line-width 2 :color ,monokai-256-background)))))
+                                       :background ,monokai-256-highlight-line
+                                       :weight bold
+                                       :slant normal
+                                       :inverse-video nil
+                                       :height ,monokai-height-plus-1
+                                       :underline nil
+                                       :box (:line-width 2 :color ,monokai-256-background)))))
 
    `(org-agenda-calendar-event
      ((,monokai-class (:foreground ,monokai-emphasis))
@@ -4330,7 +4340,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :slant italic))))
+                                       :slant italic))))
 
    `(org-agenda-date
      ((,monokai-class (:foreground ,monokai-comments
@@ -4342,13 +4352,13 @@ Also affects 'linum-mode' background."
                                    :height 1.0
                                    :box (:line-width 2 :color ,monokai-background)))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video nil
-                                        :overline nil
-                                        :slant normal
-                                        :height 1.0
-                                        :box (:line-width 2 :color ,monokai-256-background)))) t)
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video nil
+                                       :overline nil
+                                       :slant normal
+                                       :height 1.0
+                                       :box (:line-width 2 :color ,monokai-256-background)))) t)
 
    `(org-agenda-date-weekend
      ((,monokai-class (:inherit org-agenda-date
@@ -4360,13 +4370,13 @@ Also affects 'linum-mode' background."
                                 :overline nil
                                 :box unspecified))
       (,monokai-256-class (:inherit org-agenda-date
-                                     :inverse-video nil
-                                     :background unspecified
-                                     :foreground ,monokai-256-comments
-                                     :weight unspecified
-                                     :underline t
-                                     :overline nil
-                                     :box unspecified))) t)
+                                    :inverse-video nil
+                                    :background unspecified
+                                    :foreground ,monokai-256-comments
+                                    :weight unspecified
+                                    :underline t
+                                    :overline nil
+                                    :box unspecified))) t)
 
    `(org-agenda-date-today
      ((,monokai-class (:inherit org-agenda-date
@@ -4378,31 +4388,31 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-blue
                                 :background ,monokai-background))
       (,monokai-256-class (:inherit org-agenda-date
-                                     :inverse-video t
-                                     :weight bold
-                                     :underline unspecified
-                                     :overline nil
-                                     :box unspecified
-                                     :foreground ,monokai-256-blue
-                                     :background ,monokai-256-background))) t)
+                                    :inverse-video t
+                                    :weight bold
+                                    :underline unspecified
+                                    :overline nil
+                                    :box unspecified
+                                    :foreground ,monokai-256-blue
+                                    :background ,monokai-256-background))) t)
 
    `(org-agenda-done
      ((,monokai-class (:foreground ,monokai-comments
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :slant italic))) t)
+                                       :slant italic))) t)
 
    `(org-archived
      ((,monokai-class (:foreground ,monokai-comments
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(org-block
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-highlight-alt))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-highlight-alt))))
+                                       :background ,monokai-256-highlight-alt))))
 
    `(org-block-background
      ((,monokai-class (:background ,monokai-highlight-alt))
@@ -4413,24 +4423,24 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-gray-d
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-gray-d
-                                        :slant italic))))
+                                       :background ,monokai-256-gray-d
+                                       :slant italic))))
 
    `(org-block-end-line
      ((,monokai-class (:foreground ,monokai-comments
                                    :background ,monokai-gray-d
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-gray-d
-                                        :slant italic))))
+                                       :background ,monokai-256-gray-d
+                                       :slant italic))))
 
    `(org-checkbox
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-foreground
                                    :box (:line-width 1 :style released-button)))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground
-                                        :box (:line-width 1 :style released-button)))))
+                                       :foreground ,monokai-256-foreground
+                                       :box (:line-width 1 :style released-button)))))
 
    `(org-code
      ((,monokai-class (:foreground ,monokai-comments))
@@ -4440,13 +4450,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline t))))
+                                       :underline t))))
 
    `(org-done
      ((,monokai-class (:weight bold
                                :foreground ,monokai-green))
       (,monokai-256-class (:weight bold
-                                    :foreground ,monokai-256-green))))
+                                   :foreground ,monokai-256-green))))
 
    `(org-ellipsis
      ((,monokai-class (:foreground ,monokai-comments))
@@ -4469,62 +4479,62 @@ Also affects 'linum-mode' background."
                                 :height ,monokai-height-plus-4
                                 :foreground ,monokai-orange))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :height ,monokai-height-plus-4
-                                     :foreground ,monokai-256-orange))))
+                                    :height ,monokai-height-plus-4
+                                    :foreground ,monokai-256-orange))))
 
    `(org-level-2
      ((,monokai-class (:inherit ,monokai-pitch
                                 :height ,monokai-height-plus-3
                                 :foreground ,monokai-green))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :height ,monokai-height-plus-3
-                                     :foreground ,monokai-256-green))))
+                                    :height ,monokai-height-plus-3
+                                    :foreground ,monokai-256-green))))
 
    `(org-level-3
      ((,monokai-class (:inherit ,monokai-pitch
                                 :height ,monokai-height-plus-2
                                 :foreground ,monokai-blue))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :height ,monokai-height-plus-2
-                                     :foreground ,monokai-256-blue))))
+                                    :height ,monokai-height-plus-2
+                                    :foreground ,monokai-256-blue))))
 
    `(org-level-4
      ((,monokai-class (:inherit ,monokai-pitch
                                 :height ,monokai-height-plus-1
                                 :foreground ,monokai-yellow))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :height ,monokai-height-plus-1
-                                     :foreground ,monokai-256-yellow))))
+                                    :height ,monokai-height-plus-1
+                                    :foreground ,monokai-256-yellow))))
 
    `(org-level-5
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-cyan))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-cyan))))
+                                    :foreground ,monokai-256-cyan))))
 
    `(org-level-6
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-green))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-green))))
+                                    :foreground ,monokai-256-green))))
 
    `(org-level-7
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-red))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-red))))
+                                    :foreground ,monokai-256-red))))
 
    `(org-level-8
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-blue))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-blue))))
+                                    :foreground ,monokai-256-blue))))
 
    `(org-link
      ((,monokai-class (:foreground ,monokai-blue
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :underline t))))
+                                       :underline t))))
 
    `(org-sexp-date
      ((,monokai-class (:foreground ,monokai-violet))
@@ -4542,13 +4552,13 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :weight normal))))
+                                       :weight normal))))
 
    `(org-special-keyword
      ((,monokai-class (:foreground ,monokai-comments
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(org-table
      ((,monokai-class (:foreground ,monokai-green))
@@ -4566,30 +4576,30 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(org-upcoming-deadline
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal
-                                        :underline nil))))
+                                       :weight normal
+                                       :underline nil))))
 
    `(org-warning
      ((,monokai-class (:foreground ,monokai-orange
                                    :weight normal
                                    :underline nil))
       (,monokai-256-class (:foreground ,monokai-256-orange
-                                        :weight normal
-                                        :underline nil))))
+                                       :weight normal
+                                       :underline nil))))
 
    ;; org-habit (clear=blue, ready=green, alert=yellow, overdue=red. future=lower contrast)
    `(org-habit-clear-face
      ((,monokai-class (:background ,monokai-blue-lc
                                    :foreground ,monokai-blue-hc))
       (,monokai-256-class (:background ,monokai-256-blue-lc
-                                        :foreground ,monokai-256-blue-hc))))
+                                       :foreground ,monokai-256-blue-hc))))
 
    `(org-habit-clear-future-face
      ((,monokai-class (:background ,monokai-blue-lc))
@@ -4599,7 +4609,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-green-lc
                                    :foreground ,monokai-green))
       (,monokai-256-class (:background ,monokai-256-green-lc
-                                        :foreground ,monokai-256-green))))
+                                       :foreground ,monokai-256-green))))
 
    `(org-habit-ready-future-face
      ((,monokai-class (:background ,monokai-green-lc))
@@ -4609,7 +4619,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground ,monokai-yellow-lc))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-yellow-lc))))
+                                       :foreground ,monokai-256-yellow-lc))))
 
    `(org-habit-alert-future-face
      ((,monokai-class (:background ,monokai-yellow-lc))
@@ -4619,7 +4629,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-red
                                    :foreground ,monokai-red-lc))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-red-lc))))
+                                       :foreground ,monokai-256-red-lc))))
 
    `(org-habit-overdue-future-face
      ((,monokai-class (:background ,monokai-red-lc))
@@ -4646,25 +4656,25 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inherit default))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :strike-through nil
-                                        :underline nil
-                                        :slant normal
-                                        :weight normal
-                                        :inherit default))))
+                                       :strike-through nil
+                                       :underline nil
+                                       :slant normal
+                                       :weight normal
+                                       :inherit default))))
 
    `(org-column-title
      ((,monokai-class (:background ,monokai-highlight-line
                                    :underline t
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :underline t
-                                        :weight bold))))
+                                       :underline t
+                                       :weight bold))))
 
    `(org-date-selected
      ((,monokai-class (:foreground ,monokai-red
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :inverse-video t))))
+                                       :inverse-video t))))
 
    `(org-document-info
      ((,monokai-class (:foreground ,monokai-foreground))
@@ -4675,8 +4685,8 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :height ,monokai-height-plus-4))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :weight bold
-                                        :height ,monokai-height-plus-4))))
+                                       :weight bold
+                                       :height ,monokai-height-plus-4))))
 
    `(org-drawer
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -4686,7 +4696,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-magenta
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :underline t))))
+                                       :underline t))))
 
    `(org-latex-and-export-specials
      ((,monokai-class (:foreground ,monokai-orange))
@@ -4743,14 +4753,14 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight normal))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight normal))))
+                                       :weight normal))))
 
    ;; popup
    `(popup-face
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(popup-isearch-match
      ((,monokai-class (:background ,monokai-green))
@@ -4760,19 +4770,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(popup-menu-mouse-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(popup-menu-selection-face
      ((,monokai-class (:background ,monokai-magenta
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-magenta
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(popup-scroll-bar-background-face
      ((,monokai-class (:background ,monokai-comments))
@@ -4786,7 +4796,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    ;; rainbow-delimiters
    `(rainbow-delimiters-depth-1-face
@@ -4842,8 +4852,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-background
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :background ,monokai-256-background
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :inverse-video t))))
 
    ;; realgud
    `(realgud-overlay-arrow1
@@ -4889,86 +4899,86 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-delim-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-exec-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-exec-delim-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-out-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-out-delim-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-comment-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(erb-comment-delim-face
      ((,monokai-class (:foreground ,monokai-cyan
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    ;; rst-mode
    `(rst-level-1-face
      ((,monokai-class (:background ,monokai-yellow
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(rst-level-2-face
      ((,monokai-class (:background ,monokai-cyan
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-cyan
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(rst-level-3-face
      ((,monokai-class (:background ,monokai-blue
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(rst-level-4-face
      ((,monokai-class (:background ,monokai-violet
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-violet
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(rst-level-5-face
      ((,monokai-class (:background ,monokai-magenta
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-magenta
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    `(rst-level-6-face
      ((,monokai-class (:background ,monokai-red
                                    :foreground ,monokai-background))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-background))))
+                                       :foreground ,monokai-256-background))))
 
    ;; rpm-mode
    `(rpm-spec-dir-face
@@ -5012,19 +5022,19 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-violet
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-violet
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(sh-escaped-newline
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(sh-heredoc
      ((,monokai-class (:foreground ,monokai-yellow
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; smartparens
    `(sp-pair-overlay-face
@@ -5049,9 +5059,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    `(sp-show-pair-mismatch-face
      ((,monokai-class (:foreground ,monokai-red
@@ -5059,9 +5069,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    ;; show-paren
    `(show-paren-match
@@ -5070,9 +5080,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    `(show-paren-mismatch
      ((,monokai-class (:foreground ,monokai-red
@@ -5080,9 +5090,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    ;; mic-paren
    `(paren-face-match
@@ -5091,9 +5101,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    `(paren-face-mismatch
      ((,monokai-class (:foreground ,monokai-red
@@ -5101,9 +5111,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    `(paren-face-no-match
      ((,monokai-class (:foreground ,monokai-red
@@ -5111,9 +5121,9 @@ Also affects 'linum-mode' background."
                                    :weight normal
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-background
-                                        :weight normal
-                                        :inverse-video t))))
+                                       :background ,monokai-256-background
+                                       :weight normal
+                                       :inverse-video t))))
 
    ;; SLIME
    `(slime-repl-inputed-output-face
@@ -5122,58 +5132,58 @@ Also affects 'linum-mode' background."
 
    ;; smerge
    `(smerge-base
-      ((,monokai-class (:background ,monokai-diff-blue-base))
-        (,monokai-256-class (:background ,monokai-256-diff-blue-base))))
+     ((,monokai-class (:background ,monokai-diff-blue-base))
+      (,monokai-256-class (:background ,monokai-256-diff-blue-base))))
    `(smerge-upper
-      ((,monokai-class (:background ,monokai-diff-red-base))
-        (,monokai-256-class (:background ,monokai-256-diff-red-base))))
+     ((,monokai-class (:background ,monokai-diff-red-base))
+      (,monokai-256-class (:background ,monokai-256-diff-red-base))))
    `(smerge-lower
-      ((,monokai-class (:background ,monokai-diff-green-base))
-        (,monokai-256-class (:background ,monokai-256-diff-green-base))))
+     ((,monokai-class (:background ,monokai-diff-green-base))
+      (,monokai-256-class (:background ,monokai-256-diff-green-base))))
    ;; WARNING: defining this face will overwrite the next two when displaying a
    ;; smerge diff in a file.
    ;; `(smerge-refined-changed
    ;;    ((,monokai-class (:background ,monokai-diff-blue-emphasis))
    ;;      (,monokai-256-class (:background ,monokai-256-diff-blue-emphasis))))
    `(smerge-refined-added
-      ((,monokai-class (:background ,monokai-diff-green-emphasis))
-        (,monokai-256-class (:background ,monokai-256-diff-green-emphasis))))
+     ((,monokai-class (:background ,monokai-diff-green-emphasis))
+      (,monokai-256-class (:background ,monokai-256-diff-green-emphasis))))
    `(smerge-refined-removed
-      ((,monokai-class (:background ,monokai-diff-red-emphasis))
-        (,monokai-256-class (:background ,monokai-256-diff-red-emphasis))))
+     ((,monokai-class (:background ,monokai-diff-red-emphasis))
+      (,monokai-256-class (:background ,monokai-256-diff-red-emphasis))))
 
    ;; speedbar
    `(speedbar-button-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-comments))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-comments))))
+                                    :foreground ,monokai-256-comments))))
 
    `(speedbar-directory-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-blue))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-blue))))
+                                    :foreground ,monokai-256-blue))))
 
    `(speedbar-file-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-foreground))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-foreground))))
+                                    :foreground ,monokai-256-foreground))))
 
    `(speedbar-highlight-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :background ,monokai-highlight-line))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :background ,monokai-256-highlight-line))))
+                                    :background ,monokai-256-highlight-line))))
 
    `(speedbar-selected-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-yellow
                                 :underline t))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-yellow
-                                     :underline t))))
+                                    :foreground ,monokai-256-yellow
+                                    :underline t))))
 
    `(speedbar-separator-face
      ((,monokai-class (:inherit ,monokai-pitch
@@ -5181,15 +5191,15 @@ Also affects 'linum-mode' background."
                                 :foreground ,monokai-background
                                 :overline ,monokai-cyan-lc))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :background ,monokai-256-blue
-                                     :foreground ,monokai-256-background
-                                     :overline ,monokai-256-cyan-lc))))
+                                    :background ,monokai-256-blue
+                                    :foreground ,monokai-256-background
+                                    :overline ,monokai-256-cyan-lc))))
 
    `(speedbar-tag-face
      ((,monokai-class (:inherit ,monokai-pitch
                                 :foreground ,monokai-green))
       (,monokai-256-class (:inherit ,monokai-pitch
-                                     :foreground ,monokai-256-green))))
+                                    :foreground ,monokai-256-green))))
 
    ;; sunrise commander headings
    `(sr-active-path-face
@@ -5198,9 +5208,9 @@ Also affects 'linum-mode' background."
                                    :height ,monokai-height-plus-1
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-blue
-                                        :foreground ,monokai-256-background
-                                        :height ,monokai-height-plus-1
-                                        :weight bold))))
+                                       :foreground ,monokai-256-background
+                                       :height ,monokai-height-plus-1
+                                       :weight bold))))
 
    `(sr-editing-path-face
      ((,monokai-class (:background ,monokai-yellow
@@ -5208,9 +5218,9 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :height ,monokai-height-plus-1))
       (,monokai-256-class (:background ,monokai-256-yellow
-                                        :foreground ,monokai-256-background
-                                        :weight bold
-                                        :height ,monokai-height-plus-1))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold
+                                       :height ,monokai-height-plus-1))))
 
    `(sr-highlight-path-face
      ((,monokai-class (:background ,monokai-green
@@ -5218,9 +5228,9 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :height ,monokai-height-plus-1))
       (,monokai-256-class (:background ,monokai-256-green
-                                        :foreground ,monokai-256-background
-                                        :weight bold
-                                        :height ,monokai-height-plus-1))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold
+                                       :height ,monokai-height-plus-1))))
 
    `(sr-passive-path-face
      ((,monokai-class (:background ,monokai-comments
@@ -5228,9 +5238,9 @@ Also affects 'linum-mode' background."
                                    :weight bold
                                    :height ,monokai-height-plus-1))
       (,monokai-256-class (:background ,monokai-256-comments
-                                        :foreground ,monokai-256-background
-                                        :weight bold
-                                        :height ,monokai-height-plus-1))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold
+                                       :height ,monokai-height-plus-1))))
 
    ;; sunrise commander marked
    `(sr-marked-dir-face
@@ -5246,47 +5256,47 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-magenta
-                                        :foreground ,monokai-256-background
-                                        :weight bold))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold))))
 
    `(sr-alt-marked-file-face
      ((,monokai-class (:background ,monokai-magenta
                                    :foreground ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-magenta
-                                        :foreground ,monokai-256-background
-                                        :weight bold))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold))))
 
    ;; sunrise commander fstat
    `(sr-directory-face
      ((,monokai-class (:inherit dimonokai-red-directory
                                 :weight normal))
       (,monokai-256-class (:inherit dimonokai-red-directory
-                                     :weight normal))))
+                                    :weight normal))))
 
    `(sr-symlink-directory-face
      ((,monokai-class (:inherit dimonokai-red-directory
                                 :slant italic
                                 :weight normal))
       (,monokai-256-class (:inherit dimonokai-red-directory
-                                     :slant italic
-                                     :weight normal))))
+                                    :slant italic
+                                    :weight normal))))
 
    `(sr-symlink-face
      ((,monokai-class (:inherit dimonokai-red-symlink
                                 :slant italic
                                 :weight normal))
       (,monokai-256-class (:inherit dimonokai-red-symlink
-                                     :slant italic
-                                     :weight normal))))
+                                    :slant italic
+                                    :weight normal))))
 
    `(sr-broken-link-face
      ((,monokai-class (:inherit dimonokai-red-warning
                                 :slant italic
                                 :weight normal))
       (,monokai-256-class (:inherit dimonokai-red-warning
-                                     :slant italic
-                                     :weight normal))))
+                                    :slant italic
+                                    :weight normal))))
 
    ;; sunrise commander file types
    `(sr-compressed-face
@@ -5319,115 +5329,115 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:background ,monokai-256-red
-                                        :foreground ,monokai-256-background
-                                        :weight bold))))
+                                       :foreground ,monokai-256-background
+                                       :weight bold))))
 
    ;; syslog-mode
    `(syslog-ip-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-yellow))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-yellow))))
+                                       :foreground ,monokai-256-yellow))))
 
    `(syslog-hour-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-green))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-green))))
+                                       :foreground ,monokai-256-green))))
 
    `(syslog-error-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :foreground ,monokai-256-red
+                                       :weight bold))))
 
    `(syslog-warn-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-orange
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-orange
-                                        :weight bold))))
+                                       :foreground ,monokai-256-orange
+                                       :weight bold))))
 
    `(syslog-info-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-blue
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-blue
-                                        :weight bold))))
+                                       :foreground ,monokai-256-blue
+                                       :weight bold))))
 
    `(syslog-debug-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-cyan
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-cyan
-                                        :weight bold))))
+                                       :foreground ,monokai-256-cyan
+                                       :weight bold))))
 
    `(syslog-su-face
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-magenta))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-magenta))))
+                                       :foreground ,monokai-256-magenta))))
 
    ;; table
    `(table-cell
      ((,monokai-class (:foreground ,monokai-foreground
                                    :background ,monokai-highlight-line))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :background ,monokai-256-highlight-line))))
+                                       :background ,monokai-256-highlight-line))))
 
    ;; term
    `(term-color-black
      ((,monokai-class (:foreground ,monokai-background
                                    :background ,monokai-highlight-line))
       (,monokai-256-class (:foreground ,monokai-256-background
-                                        :background ,monokai-256-highlight-line))))
+                                       :background ,monokai-256-highlight-line))))
 
    `(term-color-red
      ((,monokai-class (:foreground ,monokai-red
                                    :background ,monokai-red-d))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :background ,monokai-256-red-d))))
+                                       :background ,monokai-256-red-d))))
 
    `(term-color-green
      ((,monokai-class (:foreground ,monokai-green
                                    :background ,monokai-green-d))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :background ,monokai-256-green-d))))
+                                       :background ,monokai-256-green-d))))
 
    `(term-color-yellow
      ((,monokai-class (:foreground ,monokai-yellow
                                    :background ,monokai-yellow-d))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background ,monokai-256-yellow-d))))
+                                       :background ,monokai-256-yellow-d))))
 
    `(term-color-blue
      ((,monokai-class (:foreground ,monokai-blue
                                    :background ,monokai-blue-d))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-blue-d))))
+                                       :background ,monokai-256-blue-d))))
 
    `(term-color-magenta
      ((,monokai-class (:foreground ,monokai-magenta
                                    :background ,monokai-magenta-d))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :background ,monokai-256-magenta-d))))
+                                       :background ,monokai-256-magenta-d))))
 
    `(term-color-cyan
      ((,monokai-class (:foreground ,monokai-cyan
                                    :background ,monokai-cyan-d))
       (,monokai-256-class (:foreground ,monokai-256-cyan
-                                        :background ,monokai-256-cyan-d))))
+                                       :background ,monokai-256-cyan-d))))
 
    `(term-color-white
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-foreground))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-foreground))))
+                                       :background ,monokai-256-foreground))))
 
    `(term-default-fg-color
      ((,monokai-class (:inherit term-color-white))
@@ -5446,73 +5456,73 @@ Also affects 'linum-mode' background."
 
    ;; treemacs
    `(treemacs-directory-face
-      ((,monokai-class (:foreground ,monokai-violet
-                         :background ,monokai-background
-                         :weight bold))
-        (,monokai-256-class (:foreground ,monokai-256-violet
-                              :background ,monokai-256-background
-                              :weight bold))))
+     ((,monokai-class (:foreground ,monokai-violet
+				   :background ,monokai-background
+				   :weight bold))
+      (,monokai-256-class (:foreground ,monokai-256-violet
+				       :background ,monokai-256-background
+				       :weight bold))))
 
    `(treemacs-header-face
-      ((,monokai-class (:foreground ,monokai-yellow
-                         :background ,monokai-background
-                         :underline t
-                         :weight bold))
-        (,monokai-256-class (:foreground ,monokai-256-yellow
-                              :background ,monokai-256-background
-                              :underline t
-                              :weight bold))))
+     ((,monokai-class (:foreground ,monokai-yellow
+				   :background ,monokai-background
+				   :underline t
+				   :weight bold))
+      (,monokai-256-class (:foreground ,monokai-256-yellow
+				       :background ,monokai-256-background
+				       :underline t
+				       :weight bold))))
 
    `(treemacs-git-modified-face
-      ((,monokai-class (:foreground ,monokai-green
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-green
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-green
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-green
+				       :background ,monokai-256-background))))
 
    `(treemacs-git-renamed-face
-      ((,monokai-class (:foreground ,monokai-red
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-red
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-red
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-red
+				       :background ,monokai-256-background))))
 
    `(treemacs-git-ignored-face
-      ((,monokai-class (:foreground ,monokai-gray-l
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-gray-l
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-gray-l
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-gray-l
+				       :background ,monokai-256-background))))
 
    `(treemacs-git-untracked-face
-      ((,monokai-class (:foreground ,monokai-red
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-red
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-red
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-red
+				       :background ,monokai-256-background))))
 
    `(treemacs-git-added-face
-      ((,monokai-class (:foreground ,monokai-green
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-green
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-green
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-green
+				       :background ,monokai-256-background))))
 
    `(treemacs-git-conflict-face
-      ((,monokai-class (:foreground ,monokai-orange
-                         :background ,monokai-background))
-        (,monokai-256-class (:foreground ,monokai-256-orange
-                              :background ,monokai-256-background))))
+     ((,monokai-class (:foreground ,monokai-orange
+				   :background ,monokai-background))
+      (,monokai-256-class (:foreground ,monokai-256-orange
+				       :background ,monokai-256-background))))
 
    ;; tuareg
    `(tuareg-font-lock-governing-face
      ((,monokai-class (:foreground ,monokai-magenta
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-magenta
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(tuareg-font-lock-multistage-face
      ((,monokai-class (:foreground ,monokai-blue
                                    :background ,monokai-highlight-line
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :background ,monokai-256-highlight-line
-                                        :weight bold))))
+                                       :background ,monokai-256-highlight-line
+                                       :weight bold))))
 
    `(tuareg-font-lock-operator-face
      ((,monokai-class (:foreground ,monokai-emphasis))
@@ -5523,8 +5533,8 @@ Also affects 'linum-mode' background."
                                    :background ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :background ,monokai-256-red
-                                        :weight bold))))
+                                       :background ,monokai-256-red
+                                       :weight bold))))
 
    `(tuareg-font-lock-interactive-output-face
      ((,monokai-class (:foreground ,monokai-cyan))
@@ -5539,7 +5549,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-comments
                                    :background ,monokai-background))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-background))))
+                                       :background ,monokai-256-background))))
 
    `(undo-tree-visualizer-unmodified-face
      ((,monokai-class (:foreground ,monokai-green))
@@ -5549,15 +5559,15 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-blue
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-blue
-                                        :inverse-video t))))
+                                       :inverse-video t))))
 
    `(undo-tree-visualizer-active-branch-face
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :background ,monokai-background
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :background ,monokai-256-background
-                                        :weight bold))))
+                                       :background ,monokai-256-background
+                                       :weight bold))))
 
    `(undo-tree-visualizer-register-face
      ((,monokai-class (:foreground ,monokai-yellow))
@@ -5565,8 +5575,8 @@ Also affects 'linum-mode' background."
 
    ;; volatile highlights
    `(vhl/default-face
-      ((,monokai-class (:background ,monokai-highlight-alt))
-        (,monokai-256-class (:background ,monokai-256-highlight-alt))))
+     ((,monokai-class (:background ,monokai-highlight-alt))
+      (,monokai-256-class (:background ,monokai-256-highlight-alt))))
 
    ;; w3m
    `(w3m-anchor
@@ -5581,40 +5591,40 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(w3m-header-line-location-title
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-yellow))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-yellow))))
+                                       :foreground ,monokai-256-yellow))))
 
    `(w3m-header-line-location-content
 
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(w3m-bold
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(w3m-image-anchor
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-cyan
                                    :inherit link))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-cyan
-                                        :inherit link))))
+                                       :foreground ,monokai-256-cyan
+                                       :inherit link))))
 
    `(w3m-image
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-cyan))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-cyan))))
+                                       :foreground ,monokai-256-cyan))))
 
    `(w3m-lnum-minibuffer-prompt
      ((,monokai-class (:foreground ,monokai-emphasis))
@@ -5629,8 +5639,8 @@ Also affects 'linum-mode' background."
                                   :bold nil
                                   :foreground ,monokai-red))
       (,monokai-256-class (:underline nil
-                                       :bold nil
-                                       :foreground ,monokai-256-red))))
+                                      :bold nil
+                                      :foreground ,monokai-256-red))))
 
    `(w3m-session-select
      ((,monokai-class (:foreground ,monokai-foreground))
@@ -5641,58 +5651,58 @@ Also affects 'linum-mode' background."
                                    :bold t
                                    :underline t))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :bold t
-                                        :underline t))))
+                                       :bold t
+                                       :underline t))))
 
    `(w3m-tab-background
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(w3m-tab-selected-background
      ((,monokai-class (:background ,monokai-background
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-background
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(w3m-tab-mouse
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-yellow))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-yellow))))
+                                       :foreground ,monokai-256-yellow))))
 
    `(w3m-tab-selected
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-emphasis
                                    :bold t))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-emphasis
-                                        :bold t))))
+                                       :foreground ,monokai-256-emphasis
+                                       :bold t))))
 
    `(w3m-tab-unselected
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-foreground))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-foreground))))
+                                       :foreground ,monokai-256-foreground))))
 
    `(w3m-tab-selected-retrieving
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-red))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-red))))
+                                       :foreground ,monokai-256-red))))
 
    `(w3m-tab-unselected-retrieving
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-orange))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-orange))))
+                                       :foreground ,monokai-256-orange))))
 
    `(w3m-tab-unselected-unseen
      ((,monokai-class (:background ,monokai-highlight-line
                                    :foreground ,monokai-violet))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :foreground ,monokai-256-violet))))
+                                       :foreground ,monokai-256-violet))))
 
    ;; web-mode
    `(web-mode-builtin-face
@@ -5712,16 +5722,16 @@ Also affects 'linum-mode' background."
                                   :weight unspecified
                                   :background ,monokai-highlight-line))
       (,monokai-256-class (:underline unspecified
-                                       :weight unspecified
-                                       :background ,monokai-256-highlight-line))))
+                                      :weight unspecified
+                                      :background ,monokai-256-highlight-line))))
 
    `(web-mode-doctype-face
      ((,monokai-class (:foreground ,monokai-comments
                                    :slant italic
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :slant italic
-                                        :weight bold))))
+                                       :slant italic
+                                       :weight bold))))
 
    `(web-mode-folded-face
      ((,monokai-class (:underline t))
@@ -5768,8 +5778,8 @@ Also affects 'linum-mode' background."
                                    :slant normal
                                    :weight unspecified))
       (,monokai-256-class (:foreground ,monokai-256-yellow
-                                        :slant normal
-                                        :weight unspecified))))
+                                       :slant normal
+                                       :weight unspecified))))
 
    `(web-mode-string-face
      ((,monokai-class (:foreground ,monokai-yellow))
@@ -5902,17 +5912,17 @@ Also affects 'linum-mode' background."
                                    :inverse-video unspecified
                                    :slant italic))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-comments
-                                        :inverse-video unspecified
-                                        :slant italic))))
+                                       :foreground ,monokai-256-comments
+                                       :inverse-video unspecified
+                                       :slant italic))))
 
    `(whitespace-hspace
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-emphasis
                                    :inverse-video unspecified))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-emphasis
-                                        :inverse-video unspecified))))
+                                       :foreground ,monokai-256-emphasis
+                                       :inverse-video unspecified))))
 
    `(whitespace-tab
      ((,monokai-class (:background unspecified
@@ -5920,9 +5930,9 @@ Also affects 'linum-mode' background."
                                    :inverse-video unspecified
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-red
-                                        :inverse-video unspecified
-                                        :weight bold))))
+                                       :foreground ,monokai-256-red
+                                       :inverse-video unspecified
+                                       :weight bold))))
 
    `(whitespace-newline
      ((,monokai-class(:background unspecified
@@ -5937,24 +5947,24 @@ Also affects 'linum-mode' background."
                                    :foreground ,monokai-orange-lc
                                    :inverse-video t))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-orange-lc
-                                        :inverse-video t))))
+                                       :foreground ,monokai-256-orange-lc
+                                       :inverse-video t))))
 
    `(whitespace-line
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-magenta
                                    :inverse-video unspecified))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-magenta
-                                        :inverse-video unspecified))))
+                                       :foreground ,monokai-256-magenta
+                                       :inverse-video unspecified))))
 
    `(whitespace-space-before-tab
      ((,monokai-class (:background ,monokai-red-lc
                                    :foreground unspecified
                                    :inverse-video unspecified))
       (,monokai-256-class (:background ,monokai-256-red-lc
-                                        :foreground unspecified
-                                        :inverse-video unspecified))))
+                                       :foreground unspecified
+                                       :inverse-video unspecified))))
 
    `(whitespace-indentation
      ((,monokai-class (:background unspecified
@@ -5962,17 +5972,17 @@ Also affects 'linum-mode' background."
                                    :inverse-video unspecified
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-yellow
-                                        :inverse-video unspecified
-                                        :weight bold))))
+                                       :foreground ,monokai-256-yellow
+                                       :inverse-video unspecified
+                                       :weight bold))))
 
    `(whitespace-empty
      ((,monokai-class (:background unspecified
                                    :foreground ,monokai-red-lc
                                    :inverse-video t))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-red-lc
-                                        :inverse-video t))))
+                                       :foreground ,monokai-256-red-lc
+                                       :inverse-video t))))
 
    `(whitespace-space-after-tab
      ((,monokai-class (:background unspecified
@@ -5980,9 +5990,9 @@ Also affects 'linum-mode' background."
                                    :inverse-video t
                                    :weight bold))
       (,monokai-256-class (:background unspecified
-                                        :foreground ,monokai-256-orange
-                                        :inverse-video t
-                                        :weight bold))))
+                                       :foreground ,monokai-256-orange
+                                       :inverse-video t
+                                       :weight bold))))
 
    ;; wanderlust
    `(wl-highlight-folder-few-face
@@ -6065,7 +6075,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-foreground
                                    :slant italic))
       (,monokai-256-class (:foreground ,monokai-256-foreground
-                                        :slant italic))))
+                                       :slant italic))))
 
    `(wl-highlight-summary-new-face
      ((,monokai-class (:foreground ,monokai-blue))
@@ -6091,7 +6101,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:underline t
                                   :weight bold))
       (,monokai-256-class (:underline t
-                                       :weight bold))))
+                                      :weight bold))))
 
    ;; weechat
    `(weechat-error-face
@@ -6102,15 +6112,15 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-emphasis
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-emphasis
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(weechat-nick-self-face
      ((,monokai-class (:foreground ,monokai-green
                                    :weight unspecified
                                    :inverse-video t))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight unspecified
-                                        :inverse-video t))))
+                                       :weight unspecified
+                                       :inverse-video t))))
 
    `(weechat-prompt-face
      ((,monokai-class (:inherit minibuffer-prompt))
@@ -6130,7 +6140,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-green
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-green
-                                        :weight bold))))
+                                       :weight bold))))
 
    `(which-key-separator-face
      ((,monokai-class (:foreground ,monokai-comments))
@@ -6152,7 +6162,7 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-red
                                    :weight bold))
       (,monokai-256-class (:foreground ,monokai-256-red
-                                        :weight bold))))
+                                       :weight bold))))
 
    ;; window-divider-mode
    `(window-divider
@@ -6171,20 +6181,20 @@ Also affects 'linum-mode' background."
      ((,monokai-class (:foreground ,monokai-comments
                                    :background ,monokai-comments))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-comments))))
+                                       :background ,monokai-256-comments))))
 
    `(yascroll:thumb-fringe
      ((,monokai-class (:foreground ,monokai-comments
                                    :background ,monokai-comments))
       (,monokai-256-class (:foreground ,monokai-256-comments
-                                        :background ,monokai-256-comments))))
+                                       :background ,monokai-256-comments))))
 
    ;; zencoding
    `(zencoding-preview-input
      ((,monokai-class (:background ,monokai-highlight-line
                                    :box ,monokai-emphasis))
       (,monokai-256-class (:background ,monokai-256-highlight-line
-                                        :box ,monokai-256-emphasis)))))
+                                       :box ,monokai-256-emphasis)))))
 
   (custom-theme-set-variables
    'monokai
@@ -6244,13 +6254,13 @@ Also affects 'linum-mode' background."
    ;; weechat
    `(weechat-color-list
      '(unspecified ,monokai-background ,monokai-highlight-line
-                  ,monokai-red-d ,monokai-red
-                  ,monokai-green-d ,monokai-green
-                  ,monokai-yellow-d ,monokai-yellow
-                  ,monokai-blue-d ,monokai-blue
-                  ,monokai-magenta-d ,monokai-magenta
-                  ,monokai-cyan-d ,monokai-cyan
-                  ,monokai-foreground ,monokai-emphasis))))
+                   ,monokai-red-d ,monokai-red
+                   ,monokai-green-d ,monokai-green
+                   ,monokai-yellow-d ,monokai-yellow
+                   ,monokai-blue-d ,monokai-blue
+                   ,monokai-magenta-d ,monokai-magenta
+                   ,monokai-cyan-d ,monokai-cyan
+                   ,monokai-foreground ,monokai-emphasis))))
 
 ;;;###autoload
 (when (and (boundp 'custom-theme-load-path) load-file-name)

--- a/monokai-theme.el
+++ b/monokai-theme.el
@@ -1123,9 +1123,9 @@ Also affects 'linum-mode' background."
    `(centaur-tabs-unselected ((t (:background ,monokai-highlight-line :foreground ,monokai-comments :box nil))))
    `(centaur-tabs-selected-modified ((t (:background ,monokai-background :foreground ,monokai-orange :box nil))))
    `(centaur-tabs-unselected-modified ((t (:background ,monokai-highlight-line :foreground ,monokai-orange :box nil))))
-   `(centaur-tabs-active-bar-face ((t (:background ,monokai-yellow :box nil))))
-   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-yellow :box nil))))
-   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-yellow :box nil))))
+   `(centaur-tabs-active-bar-face ((t (:background ,monokai-red :box nil))))
+   `(centaur-tabs-modified-marker-selected ((t (:inherit 'centaur-tabs-selected-modified :foreground ,monokai-red :box nil))))
+   `(centaur-tabs-modified-marker-unselected ((t (:inherit 'centaur-tabs-unselected-modified :foreground ,monokai-red :box nil))))
    
    ;; calfw
    `(cfw:face-day-title


### PR DESCRIPTION
I love this theme, but was frustrated by the lack of settings for [centaur-tabs](https://github.com/ema2159/centaur-tabs). As I've recently started working with Emacs Lisp, I've added a setting to address this complaint. If you merge this configuration, there will be fewer people like me!